### PR TITLE
Minor modifications to main page and exchanges page

### DIFF
--- a/exchanges/index.md
+++ b/exchanges/index.md
@@ -29,14 +29,16 @@ title: Exchanges
 [alcurEX](https://alcurex.org)<br>
 [btc-e](https://btc-e.com)<br>
 [Bter](https://bter.com)<br>
+[bx.in.th](https://bx.in.th)<br>
 [Cex.io](https://cex.io/nmc-btc)<br>
 [Cryptsy](https://www.cryptsy.com)<br>
 [ExchangeMyCoins](https://www.exchangemycoins.com/)<br>
+[Poloniex](https://poloniex.com)<br>
 [ShapeShift](https://shapeshift.io/)<br>
-[Vircurex](https://vircurex.com)<br>
+[Vircurex](https://vircurex.com)<sup>use with caution, see [discussion](https://bitcointalk.org/index.php?topic=49383.1200)</sup><br>
 </span>
 
-Gold, silver and bronze level exchanges donate to the Namecoin project. The higher the donation the higher the level. Note that the exchanges atm are not verified in any way.
+Gold, silver and bronze level exchanges donate to the Namecoin project. The higher the donation the higher the level. Note that the exchanges are not verified in any way.
 The current fees are 1000/300/100NMC per year*. To get on the list contact exchanges a|t namecoin.org
 
 *Kraken received an honorary silver level for supporting us with their libcoin library.

--- a/index.md
+++ b/index.md
@@ -5,9 +5,9 @@ title: Namecoin
 
 {::options parse_block_html="true" /}
 
-**Namecoin** is an experimental open-source technology which improves decentralization, security, censorship resistance, privacy, and speed of certain Internet technologies such as DNS and identities.
+**Namecoin** is an experimental open-source technology which improves decentralization, security, censorship resistance, privacy, and speed of certain components of the Internet infrastructure such as DNS and identities.
 
-(For the technically minded, Namecoin is a key/value pair registration and transfer system based on the Bitcoin cryptocurrency.)
+(For the technically minded, Namecoin is a key/value pair registration and transfer system based on the Bitcoin technology.)
 
 *Bitcoin frees money – Namecoin frees DNS, identities, and other technologies.*
 
@@ -18,10 +18,10 @@ title: Namecoin
 ## What can Namecoin be used for?
 
 * Protect free-speech rights online by making the web more resistant to censorship.
-* Access websites using the .bit top-level domain.
-* Decentralized TLS (HTTPS) certificate validation, backed by blockchain consensus.
-* Human-meaningful Tor .onion domains.
 * Attach identity information such as GPG and OTR keys and email, Bitcoin, and Bitmessage addresses to an identity of your choice.
+* Human-meaningful Tor .onion domains.
+* Decentralized TLS (HTTPS) certificate validation, backed by blockchain consensus.
+* Access websites using the .bit top-level domain.
 * Proposed ideas such as file signatures, voting, bonds/stocks/shares, web of trust, notary services, and proof of existence. (To be implemented.)
 
 </div>
@@ -44,8 +44,8 @@ What does Namecoin do under the hood?
 
 ## More Information
 
-* [.bit DNS](https://bit.namecoin.org/)
 * [Namecoin Identities](https://nameid.org)
+* [.bit DNS](https://bit.namecoin.org/)
 
 ## Donate
 Help keep us **strong**.


### PR DESCRIPTION
Replaced "Bitcoin cryptocurrency" with "Bitcoin technology".
Reordered Namecoin use cases (i.e. lowered significance of .bit feature for the moment).
Exchanges: added 2 exchanges; added warning for potential Vircurex users.