### PR TITLE
Fix broken links in header that only manifested on the beta server

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,10 +14,10 @@
                 <div class="navbar-collapse collapse" id="navbar-collapse">
                 <ul class="nav navbar-nav navbar-left">
                     <li><a href="{{site.baseurl}}">Home</a></li>
-                    <li><a href="{{site.baseurl}}exchanges">Exchanges</a></li>
-                    <li><a href="{{site.baseurl}}team">Team</a></li>
-                    <li><a href="{{site.baseurl}}explorers">Explorers</a></li>
-                    <li><a href="{{site.baseurl}}download"><!--span class="glyphicon glyphicon-download-alt"></span--> Download</a></li>
+                    <li><a href="{{site.baseurl}}exchanges/">Exchanges</a></li>
+                    <li><a href="{{site.baseurl}}team/">Team</a></li>
+                    <li><a href="{{site.baseurl}}explorers/">Explorers</a></li>
+                    <li><a href="{{site.baseurl}}download/"><!--span class="glyphicon glyphicon-download-alt"></span--> Download</a></li>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
                     <li><a href="https://forum.namecoin.info">Forum&#10138;</a></li>


### PR DESCRIPTION
This PR fixes the broken links in the header due to lack of trailing forward slashes.  The issue only is visible on the beta server (and presumably the production server); it's not a problem on the github.io mirror due to different server config.  Until this PR is merged, you can see the issue at https://beta.namecoin.org/ ; most of the links at the top return "File not found" unless you manually add a forward slash to the URL's.