### PR TITLE
Moved donations to their own (expanded) page.

### DIFF
--- a/donate/index.md
+++ b/donate/index.md
@@ -1,0 +1,51 @@
+---
+layout: page
+title: Donate
+---
+
+{::options parse_block_html="true" /}
+
+You can donate to support Namecoin via a number of methods.
+
+Note that donations are not tax-deductible.
+
+## Direct Cryptocurrency Donations
+
+The Namecoin Marketing and Development Fund (operated by Phelix) accepts donations via Bitcoin and Namecoin.
+
+* BTC: 17Si1rdVd6gaYbwLq9NkXtGV9Qzt3NmTKa
+* NMC: NDtPuyg3adscr6HCE1GUiSsKPtA8ewKgz3
+
+Warnings: Bitcoin and Namecoin do not provide anonymity for donations, although they may (under some circumstances) provide pseudonymity or location-anonymity.
+
+## ShapeShift Cryptocurrency Donations
+
+ShapeShift can be used to [donate to the Namecoin Marketing and Development Fund](https://www.shapeshift.io/) (operated by Phelix) using many cryptocurrencies other than Bitcoin and Namecoin.  Set the "Receive" address to the Bitcoin address of the Namecoin Marketing and Development Fund (see above).
+
+Warnings: Funds are handled by ShapeShift (a trusted third party).  ShapeShift is a registered company under the jurisdiction of Switzerland.  While some of the cryptocurrencies supported by ShapeShift are intended to provide some level of anonymity, the effectiveness of such anonymity features ranges from dubious to unproven.  The cryptocurrencies supported by ShapeShift may (under some circumstances) provide pseudonymity or location-anonymity.  CloudFlare (a company described by anonymity researcher Jacob Appelbaum as a global active adversary) wiretaps ShapeShift traffic, has the capability of injecting malicious changes to the ShapeShift website, and discriminates against Tor users who try to access ShapeShift.  ShapeShift takes a cut of any donations made via this method, which they state "usually falls in the range of about 0.5-1% or so."
+
+## Bountysource Donations
+
+Bountysource can be used to [donate to the Namecoin project](https://salt.bountysource.com/checkout/amount?team=namecoin) via PayPal and credit cards (VISA, MasterCard, and American Express).  Both one-time and monthly-recurring donation options are available.  The Namecoin Bountysource account is operated by Jeremy Rand.
+
+Warnings: Funds are handled by Bountysource (a trusted third party).  Bountysource is a registered company under the jurisdiction of the state of California in the U.S.  PayPal and credit cards do not provide anonymity for donations, nor do they provide pseudonymity or location-anonymity.  Bountysource takes a 10% cut of any donations made via this method.
+
+## Bountysource Issue/Task Bounties
+
+Bountysource can be used to place bounties on completion of specified issues or tasks listed on GitHub.  The bounties can be placed via PayPal or Bitcoin.  When the issue is resolved, Bountysource releases the funds to the developer who resolved it.
+
+To place a bounty on an existing issue, click the Bountysource link in the issue description.  If no issue exists for the task you want solved, create a new issue.  
+
+The following Namecoin GitHub repositories support placing Bountysource bounties:
+
+* [Meta](https://github.com/namecoin/meta/issues)
+
+More GitHub repositories may be added later.
+
+Warnings: Funds are handled by Bountysource (a trusted third party).  Bountysource is a registered company under the jurisdiction of the state of California in the U.S.  PayPal does not provide anonymity for donations, nor does it provide pseudonymity or location-anonymity.  Bitcoin donations using Bountysource are processed by Coinbase, which is not particularly anonymity-friendly.  Bountysource takes a 10% cut of any donations made via this method.
+
+## Tip4Commit Bounties
+
+We are currently looking into Tip4Commit; check back later for updates on this option.
+
+<!--CloudFlare (a company described by anonymity researcher Jacob Appelbaum as a global active adversary) wiretaps Tip4Commit traffic, has the capability of injecting malicious changes to the Tip4Commit website, and discriminates against Tor users who try to access Tip4Commit.-->

--- a/index.md
+++ b/index.md
@@ -74,10 +74,7 @@ For the latest news go to the [Namecoin forum](https://forum.namecoin.org/) or c
 Official anouncements will also be made on [this BitcoinTalk thread](https://bitcointalk.org/index.php?topic=236340.0).
 
 ## Donate
-Help keep us **strong**.
-
-* NMC: NDtPuyg3adscr6HCE1GUiSsKPtA8ewKgz3
-* BTC: 17Si1rdVd6gaYbwLq9NkXtGV9Qzt3NmTKa
+Help keep us **strong**.  [You can donate to the Namecoin project here.]({{site.baseurl}}donate/)
 
 ## Participate
 With **Namecoin** you can make a difference.  We need your **help to free information**, especially in documentation, marketing, and [coding](https://github.com/namecoin/).  You are welcome at the [forum](https://forum.namecoin.info/).  There may be [bounties](https://forum.namecoin.info/viewforum.php?f=18), too.


### PR DESCRIPTION
This expanded donations page lists additional donation options, e.g. ShapeShift and Bountysource.

Given that this PR affects donation addresses, please perform due diligence and make sure that none of the addresses have been changed.

~~(WIP because I need to remove ShapeShift temporarily -- they haven't restored Namecoin service after the attack they suffered.)~~