### PR TITLE
Temporarily remove "description" meta element.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="description" content="{{ site.description }}">
+    <!--<meta name="description" content="{{ site.description }}">-->
 
     <link href="{{ "css/bootstrap.min.css" | prepend: site.baseurl }}" rel="stylesheet">
     


### PR DESCRIPTION
The description metadata is still at the Jekyll default for the site, and that causes search engine results to suck.  Temporarily comment out the corresponding meta element as a workaround to fix our search engine results.