### PR TITLE
Remove site non-description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,10 @@
 # Site settings
 title: Namecoin
 email: your-email@domain.com
-description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+#description: > # this means to ignore newlines until "baseurl:"
+#  Write an awesome description for your new site here. You can edit this
+#  line in _config.yml. It will appear in your document head meta (for
+#  Google search results) and in your feed.xml site description.
 baseurl: "/" # the subpath of your site, e.g. /blog/
 url: "https://namecoin.org" # the base hostname & protocol for your site
 twitter_username: jekyllrb


### PR DESCRIPTION
Allow search engines to pick an excerpt from the body of each page. Stop supplying the same, default non-description in the <head> of every page on namecoin.org.