### PR TITLE
Exchanges: Remove Cryptonit.

### DIFF
--- a/exchanges/index.md
+++ b/exchanges/index.md
@@ -19,7 +19,7 @@ title: Exchanges
 
 <span style="font-size:100%;">
 **Bronze level exchanges**<br>
-[<img alt="Cryptonit" src="images/cryptonit.png" width="160px">](https://cryptonit.net)<br>
+...<br>
 </span>
 
 <span style="font-size:85%;">


### PR DESCRIPTION
Cryptonit ceased NMC trading on 2016 Sept 30.  See https://cryptonit.net/content/stop-nmc-doge-and-ppc-trading .