### PR TITLE
Add Hugo's post "Progress on ncdns-nsis".

### DIFF
--- a/_posts/2017-05-21-progress-ncdns-nsis.md
+++ b/_posts/2017-05-21-progress-ncdns-nsis.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: Progress on ncdns-nsis
+author: Hugo Landau
+tags: [News]
+---
+
+Development nears completion on the NSIS-based Namecoin and ncdns bundle
+installer for Windows.
+
+The [ncdns-nsis](https://github.com/hlandau/ncdns-nsis) repository provides
+source code for an NSIS-based installer which can automatically install and
+configure Namecoin Core, ncdns and Unbound and configure name resolution of
+`.bit` domains via Unbound.
+
+The installer can install Namecoin Core and Unbound automatically, but also
+allows users to opt out of the installation of these components if they wish to
+provide their own.
+
+Completion of the ncdns-nsis installer project will enable the Namecoin project
+to distribute a Windows binary installer providing a turnkey,
+configuration-free solution for `.bit` domain resolution. The installer is also
+intended to support reproducible builds and can be built from a POSIX system.
+
+At this point, extensive testing is the primary work remaining on the completion
+of the ncdns-nsis installer.


### PR DESCRIPTION
Source: https://github.com/hlandau/ncdns-nsis/blob/master/_doc/PROG-20170515.md

It was posted to the other repo because the NLnet funding wasn't announced here yet.  @hlandau, for future news posts feel free to submit a PR directly to this repo since NLnet funding is now announced.

As discussed at the dev meeting today, standard of review for these news posts is relatively minimal since we don't want them getting delayed too much.  If no showstoppers are raised within 3 days, I'll fix the timestamp and then merge.  **(Do not merge directly since it will have the wrong timestamp.)**