### PR TITLE
Add Jeremy's post "LibreTorNS Merged to Upstream TorNS".

### DIFF
--- a/_posts/2017-06-27-libretorns-merged-upstream.md
+++ b/_posts/2017-06-27-libretorns-merged-upstream.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: LibreTorNS Merged to Upstream TorNS
+author: Jeremy Rand
+tags: [News]
+---
+
+meejah has merged the LibreTorNS patches to [upstream TorNS](https://github.com/meejah/torns).  That means LibreTorNS is now obsolete, and you should use meejah's upstream TorNS for testing dns-prop279 going forward.
+
+Huge thanks to meejah for accepting the patch (and for the code review)!

--- a/download/betas/index.md
+++ b/download/betas/index.md
@@ -77,7 +77,7 @@ This is a tool that permits Namecoin naming (or any other naming method that spe
 ### Known Issues
 
 * Prop279 is still an early draft, and might change heavily.  dns-prop279 will change accordingly.
-* `tor` doesn't implement Prop279 (see above point); the [LibreTorNS](https://github.com/namecoin/LibreTorNS) shim is required if you want to use or test dns-prop279.
+* `tor` doesn't implement Prop279 (see above point); the [TorNS](https://github.com/meejah/TorNS) shim is required if you want to use or test dns-prop279.
 * dns-prop279 doesn't follow the current Namecoin Domain Names specification for onion service records (we might amend the specification to match dns-prop279's behavior).
 * dns-prop279 doesn't properly return error codes; all errors will be treated as `NXDOMAIN`.
 * dns-prop279 hasn't been carefully checked for proxy leaks.


### PR DESCRIPTION
As usual, if no showstoppers are raised within 3 days, I'll fix the timestamp and then merge. (Do not merge directly since it will have the wrong timestamp.)