### PR TITLE
Footer: Remove Facebook page.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,6 @@
             <ul class="list-inline">
                 <li><a href="https://github.com/namecoin"><i class="fa fa-github fa-2x" title="GitHub">GitHub</i></a></li>
                 <li><a href="https://twitter.com/Namecoin"><i class="fa fa-twitter fa-2x" title="Twitter">Twitter</i></a></li>
-                <li><a href="https://www.facebook.com/Namecoin.bit"><i class="fa fa-facebook fa-2x" title="Facebook">Facebook</i></a></li>
                 <li><a href="https://pay.reddit.com/r/namecoin"><i class="fa fa-users fa-2x" title="Reddit">Reddit</i></a></li>
             </ul>
         </div>


### PR DESCRIPTION
The Facebook page is unmaintained, its URL probably violates Facebook phishing policies (fuck you to the assclown who picked that URL without consulting me), and AFAIK no Namecoin developers use Facebook and are willing to maintain it.  It should have been removed long ago, and I'm finally getting around to doing so.