### PR TITLE
Exchanges: Rename Bitsquare to Bisq.

### DIFF
--- a/exchanges/index.md
+++ b/exchanges/index.md
@@ -9,7 +9,7 @@ title: Exchanges
 
 <span style="font-size:130%;">
 **Decentralized exchanges**<br>
-[Bitsquare](https://bitsquare.io/)<br>
+[Bisq](https://bitsquare.io/)<br>
 </span>
 
 <span style="font-size:130%;">


### PR DESCRIPTION
Bitsquare has rebranded to Bisq due to trademark concerns.