### PR TITLE
Exchanges: Remove btc-e.

### DIFF
--- a/exchanges/index.md
+++ b/exchanges/index.md
@@ -32,7 +32,6 @@ title: Exchanges
 [247exchange](https://www.247exchange.com/)<br>
 [24change](https://24change.com)<br>
 [alcurEX](https://alcurex.org)<br>
-[btc-e](https://btc-e.com)<br>
 [Bter](https://bter.com)<br>
 [bx.in.th](https://bx.in.th)<br>
 [ExchangeMyCoins](https://www.exchangemycoins.com/)<br>


### PR DESCRIPTION
btc-e seems to have been seized by the U.S. government.