### PR TITLE
Make Tumblr permalinks redirect to Jekyll.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,5 @@ github_username:  jekyll
 
 # Build settings
 markdown: kramdown
+plugins:
+  - jekyll-redirect-from

--- a/_posts/2014-07-15-namecoin-response-to-recent-no-ip-seizure.md
+++ b/_posts/2014-07-15-namecoin-response-to-recent-no-ip-seizure.md
@@ -3,6 +3,9 @@ layout: post
 title: Namecoin Response to Recent No-IP Seizure
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/91894977885/
+  - /post/91894977885/namecoin-response-to-recent-no-ip-seizure/
 ---
 On June 30, 2014, customers of the No-IP dynamic DNS service suddenly experienced an outage.  According to media reports, the outage was not caused by a technical issue or any kind of negligence by No-IP, but rather by a court order requested by Microsoft, supposedly to fight cybercrime.  For background, see [No-IP’s official statement](https://www.noip.com/blog/2014/06/30/ips-formal-statement-microsoft-takedown/?utm_source=email&utm_medium=notice&utm_campaign=letter-from-dan).
  

--- a/_posts/2014-09-09-great-aggregating-postmortem.md
+++ b/_posts/2014-09-09-great-aggregating-postmortem.md
@@ -3,6 +3,9 @@ layout: post
 title: The Great Aggregating Postmortem
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/97092159695/
+  - /post/97092159695/the-great-aggregating-postmortem/
 ---
 In the past couple of weeks, Namecoin suffered outages. Someone (whom we’ve nicknamed “The Aggregator”) tried consolidating a large quantity of “loose change” into a single address. When done correctly, this is good because it reduces the amount of data lite clients [Jeremy edit 2017 05 10: this means UTXO-pruned clients] need to keep. Unfortunately, a combination of volume and an oversight in fee policies led to miners getting knocked offline.
 

--- a/_posts/2014-09-21-retail-usage.md
+++ b/_posts/2014-09-21-retail-usage.md
@@ -3,6 +3,9 @@ layout: post
 title: Namecoin & Retail Usage
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/98072799240/
+  - /post/98072799240/namecoin-retail-usage/
 ---
 Well-meaning investors have been pushing for various currency-related use cases for Namecoin such as ATMs, acceptance at retailers, etc.  The core development team sees these efforts as benign but generally do not expend time nor funds on them.  Why would developers of a currency not place a priority on currency related use-cases?
 

--- a/_posts/2014-10-03-official-social-media-accounts.md
+++ b/_posts/2014-10-03-official-social-media-accounts.md
@@ -3,6 +3,9 @@ layout: post
 title: Official Social Media Accounts
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/99085765545/
+  - /post/99085765545/official-social-media-accounts/
 ---
 A large number of unofficial social media accounts have been making false claims about Namecoin.  While we wish to encourage a healthy community and decentralization, we take user safety very seriously. Content posted through these accounts may pose a threat to average users, and the Namecoin development team has established official social media accounts in an attempt to help protect users.
 

--- a/_posts/2014-12-06-cakes-for-competitors.md
+++ b/_posts/2014-12-06-cakes-for-competitors.md
@@ -3,6 +3,9 @@ layout: post
 title: Cakes for Competitors
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/104506865810/
+  - /post/104506865810/cakes-for-competitors/
 ---
 The proliferation of cryptocurrencies working on decentralized TLDs has spurred a narrative of competition with Namecoin. However, the distance between our communities is small, and the competition is friendly. The free software movement has shown us that multiple approaches strengthen the ecosystem. Competition is not the zero-sum game fundamentalist Chicago-school economists make it out to be.
 

--- a/_posts/2014-12-19-softfork-namecoin-0.3.80.md
+++ b/_posts/2014-12-19-softfork-namecoin-0.3.80.md
@@ -3,6 +3,9 @@ layout: post
 title: New Version 0.3.80, Softfork Upcoming
 author: Namecoin Developers
 tags: [Alerts, NamecoinQ Alerts, Releases, NamecoinQ Releases]
+redirect_from:
+  - /post/105749327770/
+  - /post/105749327770/new-version-0380-softfork/
 ---
 This release smooths the transition to a new Namecoin codebase rebased on the latest version of Bitcoin!
 

--- a/_posts/2014-12-22-early-christmas-present.md
+++ b/_posts/2014-12-22-early-christmas-present.md
@@ -3,6 +3,9 @@ layout: post
 title: Early Christmas Present for Namecoin
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/105921946435/
+  - /post/105921946435/early-christmas-present-for-namecoin/
 ---
 Christmas has come early for Namecoin: Discus Fish (aka F2Pool) has donated 20,000 namecoins to fund a reimplementation based on mainline Bitcoin!
 

--- a/_posts/2014-12-30-developer-meeting-saturday-jan-3.md
+++ b/_posts/2014-12-30-developer-meeting-saturday-jan-3.md
@@ -3,6 +3,9 @@ layout: post
 title: Developer Meeting Saturday, Jan. 3
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/106664933555/
+  - /post/106664933555/developer-meeting-saturday-jan-3/
 ---
 Lately we’ve had a few new people who are interested in joining development. This is, of course, awesome.  Unfortunately, helping them get started has been kind of ad-hoc, because there’s not a great way to have a low-latency conversation with current developers to bounce ideas off of. None of the current developers are in IRC at predictable, consistent times, and some developers are rarely on IRC at all. Forums have too much latency and overhead for quick back-and-forth discussions. This is a non-ideal situation.
 

--- a/_posts/2015-02-01-name-only-clients.md
+++ b/_posts/2015-02-01-name-only-clients.md
@@ -3,6 +3,9 @@ layout: post
 title: Name-Only Clients
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/109811339625/
+  - /post/109811339625/lightweight-resolvers/
 ---
 Currently, the only options for people wanting to resolve Namecoin names are to deploy a full node or to trust results provided by someone else. It doesn’t have to be this way, though. Like with Bitcoin [lightweight SPV](https://bitcoin.org/en/glossary/simplified-payment-verification) clients which have much smaller local storage requirements can be created for Namecoin. Unlike Bitcoin, we can have “Namecoin Name-Only Clients” that give up support for “Namecoin as a currency” in exchange for better security and even lighter storage requirements.
 

--- a/_posts/2015-03-20-node-interviews-daniel-kraft.md
+++ b/_posts/2015-03-20-node-interviews-daniel-kraft.md
@@ -3,5 +3,8 @@ layout: post
 title: N-O-D-E Interviews Daniel Kraft
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/114955200650/
+  - /post/114955200650/the-namecoin-interview-censorship-resistant/
 ---
 [Interview](http://n-o-d-e.net/post/113777384551/the-namecoin-interview-censorship-resistant) with Namecoin lead developer Daniel Kraft.

--- a/_posts/2015-09-01-why-duplicate-namespaces-are-bad-for-users.md
+++ b/_posts/2015-09-01-why-duplicate-namespaces-are-bad-for-users.md
@@ -3,6 +3,9 @@ layout: post
 title: Why Duplicate Namespaces Are Bad for Users
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/128123165075/
+  - /post/128123165075/why-duplicate-namespaces-are-bad-for-users/
 ---
 Every now and then, we’re approached by users who are asking about namespaces which duplicate functionality of the officially recommended namespaces.  Examples of these namespaces include `tor/`, `i2p/`, and `u/`.  We think these duplicate namespaces are harmful to end users.  This blog post will try to explain why duplicating functionality of existing namespaces is almost always a bad idea.
 

--- a/_posts/2015-09-29-onename-blockstore-is-much-less-secure-than-namecoin.md
+++ b/_posts/2015-09-29-onename-blockstore-is-much-less-secure-than-namecoin.md
@@ -3,6 +3,9 @@ layout: post
 title: OneName’s Blockstore is much less secure than Namecoin
 author: Namecoin Developers
 tags: [News]
+redirect_from:
+  - /post/130158040415/
+  - /post/130158040415/onenames-blockstore-is-much-less-secure-than/
 ---
 *Note: the naming system described in this post, Blockstore, is now named Blockstack.*
 


### PR DESCRIPTION
This should allow us to point `blog.namecoin.org` to `www.namecoin.org` without breaking permalinks.