### PR TITLE
Add deploy scripts for namecoin.org website.

### DIFF
--- a/_scripts/deploy_beta.sh
+++ b/_scripts/deploy_beta.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -eu -o pipefail
+shopt -s failglob
+
+DEPLOY_GHPAGES=0
+
+echo "You've already deployed to the github.io site, right?"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) break;;
+        No ) DEPLOY_GHPAGES=1; break;;
+    esac
+done
+
+if [[ "${DEPLOY_GHPAGES}" == "1" ]]
+then
+    echo ""
+    echo "Deploying to github.io..."
+    echo ""
+    bash ./deploy_ghpages.sh
+    echo ""
+    echo "Is everything working properly at github.io?"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes ) break;;
+            No ) exit;;
+        esac
+    done
+fi
+
+echo ""
+
+if [[ "$(pwd)" == */namecoin.org/_scripts ]]
+then
+    pushd ../../
+else
+    if [[ "$(pwd)" == */namecoin.org ]]
+    then
+        pushd ../
+    else
+        pushd ./
+    fi
+fi
+
+# This script is tested and 100% working.
+
+pushd namecoin.info
+git fetch origin
+git checkout beta
+git merge origin/beta
+OLD_REVISION=$(git log -1 --format=oneline | grep -oE '[^ ]+$')
+echo "$OLD_REVISION" | grep -E -e '\b([a-f0-9]{40})\b' -
+popd
+pushd namecoin.org
+git fetch origin
+git checkout master
+git merge origin/master
+COMMITS_TO_TEST=$(git shortlog --no-merges $OLD_REVISION..master)
+JEKYLL_REVISION="$(git rev-parse --verify master)"
+echo "$JEKYLL_REVISION" | grep -E -e '\b([a-f0-9]{40})\b' -
+popd
+JEKYLL_VM=offline-namecoin-jekyll-deploy
+qvm-copy-to-vm "$JEKYLL_VM" ./namecoin.org
+
+echo ""
+echo "Open a terminal in the Jekyll VM, and run the following:"
+echo "bash ~/QubesIncoming/anon-13-git-github-wip/namecoin.org/_scripts/deploy_jekyll_vm.sh"
+read -p "Press Enter when you've done this."
+
+rm -rf ./namecoin.info/*
+JEKYLL_BUILT_FILES="$HOME""/QubesIncoming/""$JEKYLL_VM""/_site/*"
+cp -a $JEKYLL_BUILT_FILES ./namecoin.info/
+rm -rf "$HOME""/QubesIncoming/""$JEKYLL_VM""/_site"
+pushd namecoin.info
+git add .
+git commit --message="Updated based on Jekyll build of $JEKYLL_REVISION"
+git push origin beta
+git checkout master
+popd
+
+popd
+
+echo ""
+echo "Finished!  The results should be available within 1 hour at:"
+echo "https://beta.namecoin.org/"
+echo "Check the website to make sure that the following commits are working as intended:"
+echo "$COMMITS_TO_TEST"

--- a/_scripts/deploy_ghpages.sh
+++ b/_scripts/deploy_ghpages.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+if [[ "$(pwd)" == */namecoin.org/_scripts ]]
+then
+    pushd ../../
+else
+    if [[ "$(pwd)" == */namecoin.org ]]
+    then
+        pushd ../
+    else
+        pushd ./
+    fi
+fi
+
+# This script is tested and 100% working.
+
+pushd namecoin.org
+git fetch origin
+COMMITS_TO_TEST=$(git shortlog --no-merges gh-pages..origin/master)
+git checkout master
+git merge origin/master
+git checkout gh-pages
+git merge origin/gh-pages
+git merge master
+git push origin gh-pages
+git checkout master
+popd
+
+popd
+
+echo ""
+echo "The results should be available within a few seconds at:"
+echo "https://namecoin.github.io/namecoin.org/"
+echo "Check the website to make sure that the following commits are working as intended:"
+echo "$COMMITS_TO_TEST"

--- a/_scripts/deploy_jekyll_vm.sh
+++ b/_scripts/deploy_jekyll_vm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+cd ~/QubesIncoming/anon-13-git-github-wip/
+
+pushd namecoin.org
+jekyll build
+qvm-copy-to-vm anon-13-git-github-wip ./_site
+popd
+rm -rf namecoin.org
+
+sudo poweroff

--- a/_scripts/deploy_public.sh
+++ b/_scripts/deploy_public.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+DEPLOY_BETA=0
+
+echo "You've already deployed to the beta site, right?"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) break;;
+        No ) DEPLOY_BETA=1; break;;
+    esac
+done
+
+if [[ "${DEPLOY_BETA}" == "1" ]]
+then
+    echo ""
+    echo "Deploying to beta..."
+    echo ""
+    bash ./deploy_beta.sh
+    echo ""
+    echo "Is everything working properly at beta?"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes ) break;;
+            No ) exit;;
+        esac
+    done
+fi
+
+echo ""
+
+if [[ "$(pwd)" == */namecoin.org/_scripts ]]
+then
+    pushd ../../
+else
+    if [[ "$(pwd)" == */namecoin.org ]]
+    then
+        pushd ../
+    else
+        pushd ./
+    fi
+fi
+
+# This script is tested and 100% working.
+
+pushd namecoin.info
+git fetch origin
+git checkout beta
+git merge origin/beta
+git checkout master
+git merge origin/master
+git merge beta
+git push origin master
+popd
+
+popd
+
+echo ""
+echo "Finished!  The results should be available within 1 hour at:"
+echo "https://www.namecoin.org/"
+echo ""
+echo "If needed, post about the change on:"
+echo "* Reddit"
+echo "* Twitter"


### PR DESCRIPTION
@cassiniNMC has expressed an interest in being able to deploy from Jekyll to the Namecoin website.  These are the scripts I routinely use to deploy.  They're slightly Qubes-specific (I run Jekyll in a dedicated offline VM), but it should be easy to adapt them to more standard GNU/Linux and macOS systems.

Note that the scripts aren't marked as executable (I figured making them executable might pose a security risk to the server), so you need to run them as `bash deploy_public.sh` instead of `./deploy_public.sh`.