### PR TITLE
BitcoinJ: release 0.2.7 source code

### DIFF
--- a/_posts/2017-11-21-spv-lookup-0.2.7.md
+++ b/_posts/2017-11-21-spv-lookup-0.2.7.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: "Namecoin Lightweight SPV Lookup Client 0.2.7 Source Code Available"
+author: Jeremy Rand
+tags: [Releases, libdohj Releases]
+---
+
+Version 0.2.7 of the Namecoin Lightweight SPV Lookup Client has had its source code released.  [Build instructions are here (it's the "bleeding-edge branch").]({{site.baseurl}}docs/bitcoinj-name-lookups/)  Binaries will be made available later.  Meanwhile, the former bleeding-edge branch (the branch that introduced leveldbtxcache mode) has graduated to partially-stable.  The former partially-stable branch has been deprecated.
+
+Happily, the 0.2.7 release is using an unmodified upstream libdohj, since Ross Nicoll from Dogecoin has merged all of my changes.  I'm still working to get the relevant ConsensusJ (formerly bitcoinj-addons) code merged upstream.  **As usual, the SPV client is experimental.  Namecoin Core is still substantially more secure against most threat models.**


### PR DESCRIPTION
As usual, if no showstoppers are raised within 3 days, I'll fix the timestamp and then merge. (Do not merge directly since it will have the wrong timestamp.)