### PR TITLE
Release Namecoin Core 0.15.99-name-tab-beta1.

### DIFF
--- a/_posts/2018-02-01-namecoin-core-0-15-99-name-tab-beta1.md
+++ b/_posts/2018-02-01-namecoin-core-0-15-99-name-tab-beta1.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: "Namecoin Core 0.15.99-name-tab-beta1 Released"
+author: Jeremy Rand
+tags: [Releases, Namecoin Core Releases]
+---
+
+Namecoin Core 0.15.99-name-tab-beta1 has been released on the [Beta Downloads page]({{site.baseurl}}download/betas/#namecoin-core).  Changes since 0.13.99-name-tab-beta1:
+
+* New features:
+    + GUI
+        - Significant rewrite of name GUI.  (Patch by brandonrobertz.)  **In particular, please torture-test the following**:
+            * Full flow for registering names.
+            * Full flow for updating and renewing names.
+            * State display in the names list.
+            * The above with mainnet, testnet, and regtest networks.
+            * The above with encrypted locked, encrypted unlocked, and unencrypted wallets.
+    + RPC
+        - Remove name operation from `createrawtransaction` RPC method; add `namerawtransaction` RPC method.  This paves the way for various future improvements to the name GUI, including coin control, anonymity, fee control, registration without unlocking the wallet twice, and decreased transaction size.  You'll need to update your scripts if you currently use the raw transaction API for name transactions.  (Reported by JeremyRand, patch by domob1812.)
+        - Restore `getblocktemplate` RPC method.  This improves workflow for software used by Bitcoin mining pools.  (Reported by DrHaribo, patch by domob1812.)
+        - Add `createauxblock` and `submitauxblock` RPC methods.  This improves workflow for software used by Bitcoin mining pools.  (Patch by bitkevin.)
+* Fixes:
+    + GUI
+        - Fix pending name registration bug, where the GUI requests a wallet unlock over and over and then errors with name registered.  (Patch by brandonrobertz.)
+        - Fix bug where names weren't showing up in the Manage Names list properly until client had been restarted.  (Patch by brandonrobertz.)
+    + P2P
+        - Update seed nodes.  This should decrease likelihood of getting stuck without peers.  (Patch by JeremyRand.)
+    + RPC
+        - Fix crash when user attempts to broadcast an invalid raw transaction containing multiple `name_update` outputs.  (Reported by maxweisspoker, patch by domob1812.)
+* Improvements from upstream Bitcoin Core.
+
+Unfortunately, Windows and macOS builds are broken in this release, so only GNU/Linux binaries are available.  We expect Windows and macOS builds to be restored for the 0.15.99-name-tab-beta2 release, which is coming soon.

--- a/download/betas/index.md
+++ b/download/betas/index.md
@@ -13,6 +13,29 @@ The more people test these downloads, the faster they'll be ready for release.  
 
 As usual, it is a good idea to verify the hashes and signatures of these downloads (especially the ones not hosted on namecoin.org).  The more people reproduced the hashes, the better.  If you're paranoid, run them inside an isolated virtual machine.
 
+## Namecoin Core
+
+* [Namecoin Core 0.15.99-name-tab-beta1 (GNU/Linux ARM 64-bit)](https://www.namecoin.org/files/namecoin-core-0.15.99-name-tab-beta1/namecoin-0.15.99-aarch64-linux-gnu.tar.gz)
+* [Namecoin Core 0.15.99-name-tab-beta1 (GNU/Linux ARM 32-bit)](https://www.namecoin.org/files/namecoin-core-0.15.99-name-tab-beta1/namecoin-0.15.99-arm-linux-gnueabihf.tar.gz)
+* [Namecoin Core 0.15.99-name-tab-beta1 (GNU/Linux x86 64-bit)](https://www.namecoin.org/files/namecoin-core-0.15.99-name-tab-beta1/namecoin-0.15.99-x86_64-linux-gnu.tar.gz)
+* [Namecoin Core 0.15.99-name-tab-beta1 (GNU/Linux x86 32-bit)](https://www.namecoin.org/files/namecoin-core-0.15.99-name-tab-beta1/namecoin-0.15.99-i686-pc-linux-gnu.tar.gz)
+* [Namecoin Core 0.15.99-name-tab-beta1 (Source code tarball)](https://www.namecoin.org/files/namecoin-core-0.15.99-name-tab-beta1/namecoin-0.15.99.tar.gz)
+* [Namecoin Core Gitian signatures](https://github.com/namecoin/gitian.sigs/)
+* [Namecoin Core source code](https://github.com/namecoin/namecoin-core/)
+
+### Things to Test
+
+* Full flow for registering names.
+* Full flow for updating and renewing names.
+* State display in the names list.
+* The above with mainnet, testnet, and regtest networks.
+* The above with encrypted locked, encrypted unlocked, and unencrypted wallets.
+
+### Known Issues
+
+* Windows builds not working (should be fixed in Beta 2)
+* macOS builds not working (should be fixed in Beta 2)
+
 ## Lightweight SPV BitcoinJ Name Lookup Client
 
 This is a drop-in replacement for Namecoin Core's name lookup functionality (e.g. for browsing .bit domains with ncdns), which synchronizes faster and uses less storage, but trusts Namecoin miners more than Namecoin Core does.


### PR DESCRIPTION
As usual, if no showstoppers are raised within 3 days, I'll fix the timestamp and then merge. (Do not merge directly since it will have the wrong timestamp.)