### PR TITLE
Release ConsensusJ-Namecoin v0.2.7 binaries.

### DIFF
--- a/_posts/2018-03-29-consensusj-0.2.7-binaries.md
+++ b/_posts/2018-03-29-consensusj-0.2.7-binaries.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: "ConsensusJ-Namecoin v0.2.7 Binaries Available"
+author: Jeremy Rand
+tags: [Releases, libdohj Releases]
+---
+
+Binaries of ConsensusJ-Namecoin (the Namecoin lightweight SPV lookup client) v0.2.7 are now released on the [Beta Downloads page]({{site.baseurl}}download/betas/#consensusj-namecoin) page.  This is based on the source code that was released earlier.  Notable new things in this release:
+
+* `leveldbtxcache` mode is merged to upstream libdohj, and has therefore had the benefit of more peer review.
+* `leveldbtxcache` mode now only stores the name scriptPubKey, not the entire transaction.  This significantly improves syncup time and storage usage.  (Currently, it uses around 65 MB of storage.)
+* Many dependency version bumps.
+
+**As usual, ConsensusJ-Namecoin is experimental.  Namecoin Core is still substantially more secure against most threat models.**

--- a/download/betas/index.md
+++ b/download/betas/index.md
@@ -36,9 +36,9 @@ As usual, it is a good idea to verify the hashes and signatures of these downloa
 * Windows builds not working (should be fixed in Beta 2)
 * macOS builds not working (should be fixed in Beta 2)
 
-## Lightweight SPV BitcoinJ Name Lookup Client
+## ConsensusJ-Namecoin
 
-This is a drop-in replacement for Namecoin Core's name lookup functionality (e.g. for browsing .bit domains with ncdns), which synchronizes faster and uses less storage, but trusts Namecoin miners more than Namecoin Core does.
+This is a lightweight SPV client that acts as a drop-in replacement for Namecoin Core's name lookup functionality (e.g. for browsing .bit domains with ncdns).  It synchronizes faster and uses less storage than Namecoin Core, but trusts Namecoin miners more than Namecoin Core does.
 
 You need to have Java installed:
 
@@ -48,36 +48,16 @@ You need to have Java installed:
 
 **If you're using Windows, you will need to install the Microsoft Visual C++ 2010 Redistributable Package.  [Download for 64-bit Windows is here.](https://www.microsoft.com/en-us/download/details.aspx?id=14632)  [Download for 32-bit Windows is here.](https://www.microsoft.com/en-us/download/details.aspx?id=5555)**
 
-[Download 0.1.1 Beta 1 (cross-platform JAR) (Hosted by Google Drive).](https://drive.google.com/file/d/0B3JMWdAb62L5UTJQYVFVcnBKWnc/view?usp=sharing)
-
-~~~
------BEGIN PGP SIGNED MESSAGE-----
-Hash: SHA256
-
-bitcoinj-addons Namecoin Name Lookup Client
-Version 0.1.1 Beta 1
-
-db19dfcc23b750c799152d3ed8ff91bf67d8c64ea98992c4fe7940c75daa3514  bitcoinj-daemon-0.1.1-SNAPSHOT.jar
------BEGIN PGP SIGNATURE-----
-Version: GnuPG v2
-
-iQIcBAEBCAAGBQJX/RRJAAoJELPy0WV4bWVw0yYP/27FaTNjPlC++yUn+7qBAIKx
-RsyPJrP1wj6MvzPO3zvUdrbs1KwE1HyPs+sf31FLLRnRsal8dpg+i5ggEhXgikRm
-9XE6FEuvYYmGapW/5osB1IOn7/DK37b3xQkC6+qZrG6IBxWUqQiQ4Ef4n6IejVy2
-UE8Y53Ttw2i12JFaS2N+607IlaH0BNXswvNIy72TRC1zSkF8IJHcaoYvn05HeGuB
-YStsuQxxZUKw71OZYuBMA5WC16WjalfqcgqxW1pDjNuoXLEyRMaSkSR4TKItfZ6p
-gMDceMQe2g2HSi3sPIA5SjumQxPNgSyucg8M2YThkt5tnTQSw2m8nY4OnUBt91Hn
-GRZMMu3yosPdz05lv/eQvA2BRjHYmg6pAxCjR0OUPJy6TuWT8KMPNl587lFb39vD
-DxgbqkL0oPm9NEBdgHDb/cOqgSner9xAZq3eO172aFdWuWXiC+ifPjzqMrOE3XeT
-QXflcy8AvJ20YyGy0DO3T4bfKBiWf7MighN5dVzylyUpoFxdgIM7cla6WZyCT3wm
-mlykAL56xPxaj+WA7dux+92mDNTyo04Vm7glf9+KFwfSPVuyfZQlK9D3U0XoIyWe
-3CVsKj+AGOzHM3MxgflW/4gDqiiW7IJ0LNrl0x3ksLuNUabmYi9ExgsFq3MCKWni
-GpcAkajMtMUk9xJjwEax
-=s/rl
------END PGP SIGNATURE-----
-~~~
+* [ConsensusJ-Namecoin v0.2.7 (cross-platform JAR)](https://www.namecoin.org/files/ConsensusJ-Namecoin/0.2.7/namecoinj-daemon-0.2.7-SNAPSHOT.jar)
+* [ConsensusJ-Namecoin v0.2.7 Signature (Release signed by Jeremy Rand)](https://www.namecoin.org/files/ConsensusJ-Namecoin/0.2.7/SHA256SUMS.asc)
 
 [Preliminary instructions are here.]({{site.baseurl}}docs/bitcoinj-name-lookups/)
+
+### Known Issues
+
+* Relies on patches to ConsensusJ that are not yet upstreamed.
+* Proxies are not yet supported.
+* Build is not yet reproducible.
 
 ## ncdns
 


### PR DESCRIPTION
As usual, if no showstoppers are raised within 3 days, I'll fix the time value and then merge. (Do not merge directly since it will have the wrong time value.)