### PR TITLE
Release Electrum-NMC v3.1.3-beta1.

### DIFF
--- a/_posts/2018-05-30-electrum-nmc-v3.1.3-beta1-released.md
+++ b/_posts/2018-05-30-electrum-nmc-v3.1.3-beta1-released.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: Electrum-NMC v3.1.3-beta1 Released
+author: Jeremy Rand
+tags: [Releases, Electrum Releases]
+---
+
+We've released Electrum-NMC v3.1.3-beta1.  This release supports Namecoin currency transactions, but does not yet support AuxPoW or name transactions.  This release is based on work by both ahmedbodi and myself.
+
+As usual, you can download it at the [Beta Downloads page]({{site.baseurl}}download/betas/#electrum-nmc).
+
+This work was funded by NLnet Foundation's Internet Hardening Fund.

--- a/download/betas/index.md
+++ b/download/betas/index.md
@@ -73,6 +73,9 @@ Electrum-NMC is a port of the lightweight Bitcoin wallet Electrum to Namecoin.
 
 * No AuxPoW support (so you can't see whether a transaction is confirmed).  As a workaround, you can check a block explorer (if you trust the explorer).
 * No name transaction support.
+* P2SH and SegWit are not yet disabled in the GUI.  Don't use those features, since P2SH and SegWit aren't enforced on Namecoin yet, meaning that coins sent to such addresses can trivially be stolen.
+* BIP44 key derivation is not yet switched to Namecoin.  Until this is fixed, don't use Electrum-NMC with the same seed as the Bitcoin version of Electrum.  When this gets fixed in the future, any coins received with the old version of Electrum-NMC will probably be inaccessible from the new version of Electrum-NMC.
+* Trezor support is not yet working.
 * Build reproducibility is not yet tested.
 
 ## ncdns

--- a/download/betas/index.md
+++ b/download/betas/index.md
@@ -59,6 +59,22 @@ You need to have Java installed:
 * Proxies are not yet supported.
 * Build is not yet reproducible.
 
+## Electrum-NMC
+
+Electrum-NMC is a port of the lightweight Bitcoin wallet Electrum to Namecoin.
+
+* [Electrum-NMC v3.1.3-beta1 for GNU/Linux](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.1.3-beta1.tar.gz)
+* [Electrum-NMC v3.1.3-beta1 for Windows (Standalone)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.1.3-beta1.exe)
+* [Electrum-NMC v3.1.3-beta1 for Windows (Portable)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.1.3-beta1-portable.exe)
+* [Electrum-NMC v3.1.3-beta1 for Windows (Installer)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.1.3-beta1-setup.exe)
+* [Electrum-NMC v3.1.3-beta1 Signature (Release signed by Jeremy Rand)](https://www.namecoin.org/files/electrum-nmc/SHA256SUMS.asc)
+
+### Known Issues
+
+* No AuxPoW support (so you can't see whether a transaction is confirmed).  As a workaround, you can check a block explorer (if you trust the explorer).
+* No name transaction support.
+* Build reproducibility is not yet tested.
+
 ## ncdns
 
 ncdns is software for accessing `.bit` domain names.  If you want to access `.bit` domain names, ncdns is most likely what you want to install.


### PR DESCRIPTION
As usual, if no showstoppers are raised within 3 days, I'll fix the time value and then merge. (Do not merge directly since it will have the wrong time value.)