### PR TITLE
Release Electrum-NMC v3.2.2.2.

### DIFF
--- a/_posts/2018-09-04-electrum-nmc-v3.2.2.2-released.md
+++ b/_posts/2018-09-04-electrum-nmc-v3.2.2.2-released.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Electrum-NMC v3.2.2.2 Released
+author: Jeremy Rand
+tags: [Releases, Electrum Releases]
+---
+
+We've released Electrum-NMC v3.2.2.2.  Here's what's new:
+
+* Fix exchange rate display.
+* Fix a few places where the UI still said "Bitcoin" instead of "Namecoin".
+* Building for macOS might work now (no official macOS binaries yet, though).
+* Code quality improvements.
+* Build script fix from upstream Electrum.
+
+As usual, you can download it at the [Beta Downloads page]({{site.baseurl}}download/betas/#electrum-nmc).
+
+This work was funded by NLnet Foundation's Internet Hardening Fund.

--- a/download/betas/index.md
+++ b/download/betas/index.md
@@ -63,11 +63,11 @@ You need to have Java installed:
 
 Electrum-NMC is a port of the lightweight Bitcoin wallet Electrum to Namecoin.
 
-* [Electrum-NMC v3.2.2 for GNU/Linux](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2/electrum-nmc-nc3.2.2.tar.gz)
-* [Electrum-NMC v3.2.2 for Windows (Standalone)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2/electrum-nmc-nc3.2.2.exe)
-* [Electrum-NMC v3.2.2 for Windows (Portable)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2/electrum-nmc-nc3.2.2-portable.exe)
-* [Electrum-NMC v3.2.2 for Windows (Installer)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2/electrum-nmc-nc3.2.2-setup.exe)
-* [Electrum-NMC v3.2.2 Signature (Release signed by Jeremy Rand)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2/SHA256SUMS.asc)
+* [Electrum-NMC v3.2.2.2 for GNU/Linux](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2.2/electrum-nmc-nc3.2.2.2.tar.gz)
+* [Electrum-NMC v3.2.2.2 for Windows (Standalone)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2.2/electrum-nmc-nc3.2.2.2.exe)
+* [Electrum-NMC v3.2.2.2 for Windows (Portable)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2.2/electrum-nmc-nc3.2.2.2-portable.exe)
+* [Electrum-NMC v3.2.2.2 for Windows (Installer)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2.2/electrum-nmc-nc3.2.2.2-setup.exe)
+* [Electrum-NMC v3.2.2.2 Signature (Release signed by Jeremy Rand)](https://www.namecoin.org/files/electrum-nmc/electrum-nmc-3.2.2.2/SHA256SUMS.asc)
 
 ### Known Issues
 


### PR DESCRIPTION
As usual, if no showstoppers are raised within 3 days, I'll fix the time value and then merge. (Do not merge directly since it will have the wrong time value.)