### PR TITLE
Remove some defunct exchanges

### DIFF
--- a/exchanges/index.md
+++ b/exchanges/index.md
@@ -29,17 +29,13 @@ title: Exchanges
 
 <span style="font-size:85%;">
 **Basic level exchanges**<br>
-[24change](https://24change.com)<br>
 [AltCoinTrader](https://www.altcointrader.co.za/nmc)<br>
 [Bleutrade](https://bleutrade.com/exchange/NMC/BTC)<br>
 [bx.in.th](https://bx.in.th)<br>
 [Cryptopia](https://www.cryptopia.co.nz/Exchange?market=NMC_BTC)<br>
-[Livecoin](https://www.livecoin.net/)<br>
+[Livecoin](https://www.livecoin.net)<br>
 [Poloniex](https://poloniex.com)<br>
-[ShapeShift](https://shapeshift.io/)<br>
 [Tux Exchange](https://www.tuxexchange.com/trade?coin=NMC&market=BTC)<br>
-[Vircurex](https://vircurex.com)<sup>use with caution, see [discussion](https://bitcointalk.org/index.php?topic=49383.1200)</sup><br>
-[WEX](https://wex.nz/)<br>
 </span>
 
 Gold, silver and bronze level exchanges donate to the Namecoin project. The higher the donation the higher the level. Note that the exchanges are not verified in any way.


### PR DESCRIPTION
- 24change.me: 503, https://en.bitcoin.it/wiki/24change says it to be a likely scam
- Shapeshift: does not appear to exchange Namecoin anymore
- Vircurex: 502
- WEX: gone, see https://bitcointalk.org/index.php?topic=4852278.80