### PR TITLE
Add Electrum-NMC to list of name wallets

### DIFF
--- a/docs/ncdns/index.md
+++ b/docs/ncdns/index.md
@@ -42,12 +42,12 @@ TLS instructions for ncdns on GNU/Linux are at the [TLS Client Compatibility]({{
 
 ## Supplying your own Namecoin node
 
-The ncdns Windows installer will offer to install Namecoin Core or the BitcoinJ/libdohj SPV client, and configure ncdns to use it.  However, there are several reasons why you might want to supply your own Namecoin node:
+The ncdns Windows installer will offer to install Namecoin Core or ConsensusJ-Namecoin, and configure ncdns to use it.  However, there are several reasons why you might want to supply your own Namecoin node:
 
 * You're not using Windows.
-* You want to use a Namecoin node that isn't Namecoin Core or the BitcoinJ/libdohj SPV client.
+* You want to use a Namecoin node that isn't Namecoin Core or ConsensusJ-Namecoin.
 * You want to run a Namecoin node on a different machine than ncdns.
-* You want to handle updating Namecoin Core separately from updating ncdns.
+* You want to handle updating your Namecoin node separately from updating ncdns.
 
 If you want to supply your own Namecoin node, you can follow these steps:
 

--- a/docs/tor-resolution/index.md
+++ b/docs/tor-resolution/index.md
@@ -17,7 +17,7 @@ Hopefully you've already done this.  Note that these instructions are not tested
 
 **If you're using the ncdns for Windows installer, you can skip this step.**
 
-This could be either Namecoin Core or the BitcoinJ name lookup client.  Note that if you're using Namecoin Core, you may wish to make Namecoin Core route its traffic over Tor (this procedure should be identical as what you'd do for Bitcoin Core).  The BitcoinJ name lookup client doesn't yet support routing its traffic over Tor.  If you're using the BitcoinJ name lookup client, it is strongly recommended that you use `leveldbtxcache` mode (this is the default if you're running the shortcut created by the ncdns for Windows installer; it is **not** the default if you're running it from the command line); this is because the other modes will generate network traffic that isn't subject to stream isolation.
+This could be either Namecoin Core or ConsensusJ-Namecoin.  Note that if you're using Namecoin Core, you may wish to make Namecoin Core route its traffic over Tor (this procedure should be identical as what you'd do for Bitcoin Core).  ConsensusJ-Namecoin doesn't yet support routing its traffic over Tor.  If you're using ConsensusJ-Namecoin, it is strongly recommended that you use `leveldbtxcache` mode (this is the default if you're running the shortcut created by the ncdns for Windows installer; it is **not** the default if you're running it from the command line); this is because the other modes will generate network traffic that isn't subject to stream isolation.  Electrum-NMC is not recommended because it will generate network traffic that isn't subject to stream isolation.
 
 ## Install ncdns
 

--- a/download/betas/index.md
+++ b/download/betas/index.md
@@ -156,7 +156,7 @@ See the [Namecoin Tor resolution documentation]({{site.baseurl}}docs/tor-resolut
 * dns-prop279 doesn't properly return error codes; all errors will be treated as `NXDOMAIN`.
 * dns-prop279 hasn't been carefully checked for proxy leaks.
 * Using dns-prop279 will make you stand out from other Tor users.
-* Stream isolation for streams opened by applications (e.g. Tor Browser) should work fine.  However, stream isolation metadata won't propagate to streams opened by the DNS server.  That means you should only use `dns-prop279` with a DNS server that will not generate outgoing traffic when you query it.  ncdns is probably fine as long as it's using a full-block-receive Namecoin node such as Namecoin Core or libdohj-namecoin in leveldbtxcache mode.  Unbound is not a good idea.
+* Stream isolation for streams opened by applications (e.g. Tor Browser) should work fine.  However, stream isolation metadata won't propagate to streams opened by the DNS server.  That means you should only use `dns-prop279` with a DNS server that will not generate outgoing traffic when you query it.  ncdns is probably fine as long as it's using a full-block-receive Namecoin node such as Namecoin Core or libdohj-namecoin in leveldbtxcache mode.  ncdns should **not** be used with headers-only name lookup clients such as Electrum-NMC.  Unbound is also not a good idea.
 * Nothing in dns-prop279 prevents the configured DNS server from caching lookups. If lookups are cached, this could be used to fingerprint users. ncdns has caching enabled by default.
 * DNSSEC support hasn't been tested at all, and is probably totally unsafe right now. Only use dns-prop279 when you fully trust the configured DNS server and your network path to it.
 * Build is not yet reproducible.

--- a/get-started/get-namecoins/index.md
+++ b/get-started/get-namecoins/index.md
@@ -9,7 +9,7 @@ Namecoins are a token-like currency used to register and update Namecoin names. 
 
 ## Prerequisites
 
-To get namecoins, you first need a Namecoin wallet such as Namecoin Core.  See the [Downloads]({{site.baseurl}}download/) page.
+To get namecoins, you first need a [Namecoin wallet]({{site.baseurl}}get-started/name-wallets/).
 
 ## Exchanges
 

--- a/get-started/name-wallets/index.md
+++ b/get-started/name-wallets/index.md
@@ -5,6 +5,13 @@ title: Name Wallets
 
 {::options parse_block_html="true" /}
 
-To register a Namecoin name, you need a Namecoin wallet that supports name operations.  Currently, that means you want Namecoin Core.  Namecoin Core includes both a Qt GUI (Namecoin-Qt) and a command-line version (namecoind).  You can download Namecoin Core at the [Downloads]({{site.baseurl}}download/) page.
+To register a Namecoin name, you need a Namecoin wallet that supports name operations.
 
-After you've installed Namecoin Core, you'll need to [obtain some NMC]({{site.baseurl}}get-started/get-namecoins) (the digital currency used by Namecoin).
+Your options are:
+
+* **Namecoin Core**
+   Namecoin Core is the port of Bitcoin Core to Namecoin.  Namecoin Core is a fully validating node, is reproducibly built, and supports Tor.  Namecoin Core includes both a Qt GUI and a command-line version.  You can download Namecoin Core at the [Downloads]({{site.baseurl}}download/) page.
+* **Electrum-NMC**
+   Electrum-NMC is the port of Electrum to Namecoin.  Electrum-NMC is written in a memory-safe language (Python), which is more secure than Namecoin Core.  Electrum-NMC isn't a full node, which is less secure than Namecoin Core but allows it to synchronize faster and use less storage than Namecoin Core.  Electrum-NMC is not reproducibly built.  Electrum-NMC supports Tor.  Electrum-NMC includes both a PyQt GUI and a command-line version.  See the [Electrum-NMC documentation]({{site.baseurl}}docs/electrum-nmc/).
+
+After you've installed a name wallet, you'll need to [obtain some NMC]({{site.baseurl}}get-started/get-namecoins) (the digital currency used by Namecoin).


### PR DESCRIPTION
Also give equal time to ConsensusJ-Namecoin and Electrum-NMC in other parts of the docs where appropriate.

Fixes https://github.com/namecoin/namecoin.org/issues/371