### PR TITLE
Add proposals repo link to Docs for Name Owners

### DIFF
--- a/docs/name-owners/index.md
+++ b/docs/name-owners/index.md
@@ -5,6 +5,7 @@ title: Documentation for Name Owners
 
 {::options parse_block_html="true" /}
 
+* [JSON value specifications](https://github.com/namecoin/proposals)
 * [Delegated Alteration](delegated-alteration/)
 * [TLS](tls/)
 * [DNSSEC](dnssec/)


### PR DESCRIPTION
No idea why this wasn't prominently linked already, but I got a tech support request today that would have been easily avoided if this had been linked.  So I'm fixing it.