### PR TITLE
Use www subdomain in config yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "/" # the subpath of your site, e.g. /blog/
-url: "https://namecoin.org" # the base hostname & protocol for your site
+url: "https://www.namecoin.org" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
The 2nd-level domain will soon redirect to the www subdomain, so we should improve latency by making links (e.g. the RSS feed) point to www.