### PR TITLE
Add DNSSEC-HSTS docs

### DIFF
--- a/_includes/tls_chromium_linux.md
+++ b/_includes/tls_chromium_linux.md
@@ -11,3 +11,5 @@
 {% include tls_restrict_chromium_tool.md %}
 
 {% include tls_restrict_nss_tool.md %}
+
+{% include tls_dnssec_hsts_webext_system.md %}

--- a/_includes/tls_dnssec_hsts_webext_pref.md
+++ b/_includes/tls_dnssec_hsts_webext_pref.md
@@ -1,0 +1,21 @@
+## Strict Transport Security
+
+{{ page.application }} for {{ os }} can be used with Namecoin for Strict Transport Security; this improves security against sslstrip-style attacks by forcing HTTPS to be used for `.bit` domains that support HTTPS.  Instructions:
+
+1. Install [ncdns]({{site.baseurl}}docs/ncdns/).
+1. Download and extract the DNSSEC-HSTS Native Component from the [Beta Downloads]({{site.baseurl}}download/betas/#dnssec-hsts) page.
+1. Install the DNSSEC-HSTS Native Component like this{% if nativemessagingdirrelative %}(substitute your Tor Browser directory){% endif %}:
+   
+       sudo mkdir -p {{ nativemessagingdir }}/
+       sudo cp ./org.namecoin.dnssec_hsts.json {{ nativemessagingdir }}/
+       sudo cp ./dnssec_hsts /usr/bin/
+   
+1. Go to `about:config` in {{ page.application }}.
+1. Search for `xpinstall.signatures.required`.
+1. If the `Value` column says `true`, double-click it to turn it to `false`.
+1. Close the `about:config` tab in {{ page.application }}.
+1. Restart {{ page.application }}.
+1. Download the DNSSEC-HSTS WebExtensions Component from the [Beta Downloads]({{site.baseurl}}download/betas/#dnssec-hsts) page.
+1. Open the DNSSEC-HSTS `.xpi` file in {{ page.application }}, and accept the extension installation dialog.
+
+`.bit` domains that support HTTPS will now automatically redirect from HTTP to HTTPS in {{ page.application }}.

--- a/_includes/tls_dnssec_hsts_webext_system.md
+++ b/_includes/tls_dnssec_hsts_webext_system.md
@@ -1,0 +1,37 @@
+{% if page.application == "Firefox" %}
+{% assign enableaddonsdialog = "1" %}
+{% assign nativemessaging = "1" %}
+{% endif %}
+
+## Strict Transport Security
+
+{{ page.application }} for {{ os }} can be used with Namecoin for Strict Transport Security; this improves security against sslstrip-style attacks by forcing HTTPS to be used for `.bit` domains that support HTTPS.  Instructions:
+
+1. Install [ncdns]({{site.baseurl}}docs/ncdns/).
+{% if nativemessaging %}1. Download and extract the DNSSEC-HSTS Native Component from the [Beta Downloads]({{site.baseurl}}download/betas/#dnssec-hsts) page.
+1. Install the DNSSEC-HSTS Native Component like this:
+   
+       sudo cp ./org.namecoin.dnssec_hsts.json {{ nativemessagingdir }}/
+       sudo cp ./dnssec_hsts /usr/bin/
+   
+{% else %}1. Download and extract certdehydrate-dane-rest-api from the [Beta Downloads]({{site.baseurl}}download/betas/) page.
+1. Create a text file called `certdehydrate-dane-rest-api.conf` in the same directory where `{{ certdehydratedanerestapifile }}` is, and fill it with the following contents (if ncdns is listening on a different IP or port, change the following accordingly):
+   
+       [certdehydrate-dane-rest-api]
+       nameserver="127.0.0.1"
+       port="5391"
+   
+1. Run `{{ certdehydratedanerestapifile }}`.
+1. If you want to test certdehydrate-dane-rest-api, try visiting `http://127.0.0.1:8080/lookup?domain=ca-test.bit` in a web browser.  You should see a certificate.  If you instead get an error or an empty page, something is wrong.
+{% endif %}1. Download the DNSSEC-HSTS WebExtensions Component from the [Beta Downloads]({{site.baseurl}}download/betas/#dnssec-hsts) page.
+1. Install the DNSSEC-HSTS WebExtensions Component like this:
+   
+       unzip -d ./dnssec-hsts ./dnssec-hsts-*.xpi
+       sudo rm -rf /usr/share/webext/dnssec-hsts/
+       sudo cp -a ./dnssec-hsts /usr/share/webext/dnssec-hsts
+       sudo ln -s -T /usr/share/webext/dnssec-hsts "{{ page.webextsystem }}/dnssec-hsts"
+   
+
+You may need to restart {{ page.application }}.  {% if enableaddonsdialog %}You may need to enable DNSSEC-HSTS in the {{ page.application }} Addons dialog.
+
+`.bit` domains that support HTTPS will now automatically redirect from HTTP to HTTPS in {{ page.application }}.

--- a/_includes/tls_tor_browser.md
+++ b/_includes/tls_tor_browser.md
@@ -1,0 +1,8 @@
+{% assign nativemessagingdir = "tor-browser_en-US/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts" %}
+{% assign nativemessagingdirrelative = 1 %}
+
+{% include tls_ncp11.md %}
+
+{% if os == "GNU/Linux" %}
+{% include tls_dnssec_hsts_webext_pref.md %}
+{% endif %}

--- a/docs/tls-client/chromium/gnu-linux/index.md
+++ b/docs/tls-client/chromium/gnu-linux/index.md
@@ -3,6 +3,7 @@ layout: "page"
 title: "TLS for Chromium on GNU/Linux"
 application: "Chromium"
 chromiumprofile: "$HOME/.config/chromium"
+webextsystem: "/usr/share/chromium/extensions"
 ---
 
 {% include tls_chromium_linux.md %}

--- a/docs/tls-client/firefox/gnu-linux/index.md
+++ b/docs/tls-client/firefox/gnu-linux/index.md
@@ -2,9 +2,13 @@
 layout: page
 title: "TLS for Firefox on GNU/Linux"
 application: "Firefox"
+webextsystem: "/usr/share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
 ---
 
 {% assign nssdbdir = "$HOME/.mozilla/firefox" %}
+{% assign nativemessagingdir = "/usr/lib64/mozilla/native-messaging-hosts" %}
 {% assign os = "GNU/Linux" %}
 
 {% include tls_mozilla_pkix.md %}
+
+{% include tls_dnssec_hsts_webext_system.md %}

--- a/docs/tls-client/index.md
+++ b/docs/tls-client/index.md
@@ -9,31 +9,33 @@ Namecoin can be used for TLS certificate validation.  This page covers Namecoin'
 
 ## TLS Validation Library Compatibility
 
-|  | **Positive Overrides** | **Negative Overrides** |
----|------------------------|------------------------|
-| **Chromium (all OS's)** | Not supported. | Supported via `tlsrestrict_chromium_tool`. |
-| **CryptoAPI (Windows)** | Supported via ncdns's `certinject` feature. | Not supported. |
-| **mozilla::pkix/NSS/sqlite (OS's with NSS `certutil`)** | Supported via ncdns's `tlsoverridefirefox` feature. | Supported via `tlsrestrict_nss_tool`. |
-| **mozilla::pkix/NSS/sqlite (OS's without NSS `certutil`)** | Supported via ncdns's `tlsoverridefirefox` feature. | Not supported. |
-| **mozilla::pkix/NSS/BDB** | Supported via ncdns's `tlsoverridefirefox` feature. | Not supported. |
-| **mozilla::pkix/NSS/PKCS#11** | Supported via ncp11. | Supported via ncp11. |
-| **NSS/sqlite (OS's with NSS `certutil`)** | Supported via ncdns's `certinject` feature. | Supported via `tlsrestrict_nss_tool`. |
+|  | **Positive Overrides** | **Negative Overrides** | **Strict Transport Security** |
+---|------------------------|------------------------|-------------------------------|
+| **Chromium (all OS's)** | Not supported. | Supported via `tlsrestrict_chromium_tool`. | Not supported. |
+| **CryptoAPI (Windows)** | Supported via ncdns's `certinject` feature. | Not supported. | Not supported. |
+| **mozilla::pkix/NSS/sqlite (OS's with NSS `certutil`)** | Supported via ncdns's `tlsoverridefirefox` feature. | Supported via `tlsrestrict_nss_tool`. | Not supported. |
+| **mozilla::pkix/NSS/sqlite (OS's without NSS `certutil`)** | Supported via ncdns's `tlsoverridefirefox` feature. | Not supported. | Not supported. |
+| **mozilla::pkix/NSS/BDB** | Supported via ncdns's `tlsoverridefirefox` feature. | Not supported. | Not supported. |
+| **mozilla::pkix/NSS/PKCS#11** | Supported via ncp11. | Supported via ncp11. | Not supported. |
+| **NSS/sqlite (OS's with NSS `certutil`)** | Supported via ncdns's `certinject` feature. | Supported via `tlsrestrict_nss_tool`. | Not supported. |
+| **WebExtensions (Asynchronous WebRequest)** | Not supported. | Not supported. | Supported via DNSSEC-HSTS with Native Messaging. |
+| **WebExtensions (Synchronous WebRequest)** | Not supported. | Not supported. | Supported via DNSSEC-HSTS with HTTP API. |
 
 ## TLS Application Compatibility
 
-|  | **Positive Overrides** | **Negative Overrides** |
----|------------------------|------------------------|
-| **Chromium (GNU/Linux)**<br>[Instructions](chromium/gnu-linux/) | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. |
-| **Chromium (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. |
-| **Firefox (GNU/Linux)**<br>[Instructions](firefox/gnu-linux/) | Supported via mozilla::pkix/NSS/sqlite. | Supported via mozilla::pkix/NSS/sqlite. |
-| **Firefox (Windows)**<br>[Instructions](firefox/windows/) | Supported via mozilla::pkix/NSS/sqlite. | Supported via mozilla::pkix/NSS/sqlite. |
-| **Google Chrome (GNU/Linux)** | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. |
-| **Google Chrome (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. |
-| **Google Chrome Canary (GNU/Linux)** | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. |
-| **Google Chrome Canary (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. |
-| **Opera (GNU/Linux)** | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. |
-| **Opera (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. |
-| **Tor Browser (GNU/Linux)** <br> [Instructions](tor-browser/gnu-linux/) | Supported via mozilla::pkix/NSS/PKCS#11. | Supported via mozilla::pkix/NSS/PKCS#11. |
-| **Tor Browser (macOS)** <br> [Instructions](tor-browser/macos/) | Supported via mozilla::pkix/NSS/PKCS#11.<br> **Untested** | Supported via mozilla::pkix/NSS/PKCS#11.<br> **Untested** |
-| **Tor Browser (Windows)** <br> [Instructions](tor-browser/windows/) | Supported via mozilla::pkix/NSS/PKCS#11. | Supported via mozilla::pkix/NSS/PKCS#11. |
+|  | **Positive Overrides** | **Negative Overrides** | **Strict Transport Security** |
+---|------------------------|------------------------|-------------------------------|
+| **Chromium (GNU/Linux)**<br>[Instructions](chromium/gnu-linux/) | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. | Supported via WebExtensions (Synchronous WebRequest). |
+| **Chromium (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. | Not supported. |
+| **Firefox (GNU/Linux)**<br>[Instructions](firefox/gnu-linux/) | Supported via mozilla::pkix/NSS/sqlite. | Supported via mozilla::pkix/NSS/sqlite. | Supported via WebExtensions (Asynchronous WebRequest). |
+| **Firefox (Windows)**<br>[Instructions](firefox/windows/) | Supported via mozilla::pkix/NSS/sqlite. | Supported via mozilla::pkix/NSS/sqlite. | Not supported. |
+| **Google Chrome (GNU/Linux)** | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. | Not supported. |
+| **Google Chrome (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. | Not supported. |
+| **Google Chrome Canary (GNU/Linux)** | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. | Not supported. |
+| **Google Chrome Canary (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. | Not supported. |
+| **Opera (GNU/Linux)** | Supported via NSS/sqlite. | Supported via Chromium.<br>Supported via NSS/sqlite. | Not supported. |
+| **Opera (Windows)**<br>Automatically enabled by installer | Supported via CryptoAPI. | Supported via Chromium. | Not supported. |
+| **Tor Browser (GNU/Linux)** <br> [Instructions](tor-browser/gnu-linux/) | Supported via mozilla::pkix/NSS/PKCS#11. | Supported via mozilla::pkix/NSS/PKCS#11. | Supported via WebExtensions (Asynchronous WebRequest). |
+| **Tor Browser (macOS)** <br> [Instructions](tor-browser/macos/) | Supported via mozilla::pkix/NSS/PKCS#11.<br> **Untested** | Supported via mozilla::pkix/NSS/PKCS#11.<br> **Untested** | Not supported. |
+| **Tor Browser (Windows)** <br> [Instructions](tor-browser/windows/) | Supported via mozilla::pkix/NSS/PKCS#11. | Supported via mozilla::pkix/NSS/PKCS#11. | Not supported. |
 

--- a/docs/tls-client/tor-browser/gnu-linux/index.md
+++ b/docs/tls-client/tor-browser/gnu-linux/index.md
@@ -6,4 +6,4 @@ application: "Tor Browser"
 
 {% assign os = "GNU/Linux" %}
 
-{% include tls_ncp11.md %}
+{% include tls_tor_browser.md %}

--- a/docs/tls-client/tor-browser/macos/index.md
+++ b/docs/tls-client/tor-browser/macos/index.md
@@ -6,4 +6,4 @@ application: "Tor Browser"
 
 {% assign os = "macOS" %}
 
-{% include tls_ncp11.md %}
+{% include tls_tor_browser.md %}

--- a/docs/tls-client/tor-browser/windows/index.md
+++ b/docs/tls-client/tor-browser/windows/index.md
@@ -6,4 +6,4 @@ application: "Tor Browser"
 
 {% assign os = "Windows" %}
 
-{% include tls_ncp11.md %}
+{% include tls_tor_browser.md %}


### PR DESCRIPTION
Initially only covers GNU/Linux versions of Chromium, Firefox, and Tor Browser.