### PR TITLE
Update TLS Docs for Name Owners

### DIFF
--- a/docs/name-owners/tls/index.md
+++ b/docs/name-owners/tls/index.md
@@ -5,9 +5,11 @@ title: Setting up TLS (for name owners)
 
 {::options parse_block_html="true" /}
 
-ncdns includes the tool `generate_nmc_cert`.  This tool can be used to create a self-signed Namecoin TLS certificate that is compatible with ncdns's Chromium integration.  (Standard certificate generation tools like `openssl` are not usable for this purpose.)
+ncdns includes the tool `generate_nmc_cert`.  `generate_nmc_cert` can be used to create a TLS certificate that will be recognized as valid by TLS implementations where Namecoin is installed.  (Standard certificate generation tools like `openssl` are not usable for this purpose.)
 
-Example usage:
+There are currently 2 forms of Namecoin TLS certificates: Dehydrated and Constrained.  The Dehydrated form is older and is supported by more TLS implementations.  The Constrained form is more secure and uses less blockchain storage.  It is likely that the Dehydrated form will be phased out once the Constrained form has caught up in terms of compatibility.  By default, `generate_nmc_cert` will produce a Dehydrated certificate.
+
+Example usage (Dehydrated form):
 
 ~~~
 $ ./generate_nmc_cert -host www.example.bit
@@ -17,9 +19,31 @@ $ ./generate_nmc_cert -host www.example.bit
 2019/12/11 06:47:41 SUCCESS: The cert rehydrated to an identical form.  Place the generated files in your HTTPS server, and place the above JSON in the "tls" field for your Namecoin name.
 ~~~
 
-By default, certificates use the P256 curve and are valid from generation time for approximately 1 year.  Users who know what they are doing can choose different ECDSA curves or validity periods; use the `-help` option to see the list of available options.
+To produce a Constrained certificate instead, use the `-use-ca` command-line flag, like this:
 
-The JSON object displayed should be enclosed in an array, and placed in the `tls` field for the domain where you want the TLSA record to appear.  Usually, this will be the `_443._tcp` subdomain of the domain name that points to the website.  An example of a typical configuration is:
+~~~
+$ ./generate_nmc_cert -host www.example.bit -use-ca
+2019/12/11 06:54:39 Your CA's "tls" record is: [2, 1, 0, "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEm1nvuS+A5WFgafCeYmzVSZOsokU1Fmnh5ZiBC7h0pRkbkx7cCA/MYPPh6zDdMB75ELvXSt0eLaoQQYaz1QDijw=="]
+2019/12/11 06:54:39 written caKey.pem
+2019/12/11 06:54:39 written cert.pem
+2019/12/11 06:54:39 written key.pem
+2019/12/11 06:54:39 SUCCESS.  Place cert.pem and key.pem in your HTTPS server, and place the above JSON in the "tls" field for your Namecoin name.
+~~~
+
+If you're using the Constrained form, you can produce multiple certificates for a single Namecoin record.  This allows you to, for example, rotate TLS keys periodically without needing to update your Namecoin record.  To create a new certificate using an existing Namecoin record, set the `-parent-key` command-line argument to the `caKey.pem` file that you created with the first certificate, like this:
+
+~~~
+$ ./generate_nmc_cert -host www.example.bit -use-ca -parent-key ./caKey-www.example.bit.pem
+2019/12/11 07:11:06 Using existing CA private key
+2019/12/11 07:11:06 Your CA's "tls" record is: [2, 1, 0, "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEm1nvuS+A5WFgafCeYmzVSZOsokU1Fmnh5ZiBC7h0pRkbkx7cCA/MYPPh6zDdMB75ELvXSt0eLaoQQYaz1QDijw=="]
+2019/12/11 07:11:06 written cert.pem
+2019/12/11 07:11:06 written key.pem
+2019/12/11 07:11:06 SUCCESS.  Place cert.pem and key.pem in your HTTPS server, and place the above JSON in the "tls" field for your Namecoin name.
+~~~
+
+By default, certificates use the P256 curve and are valid from generation time for approximately 1 year.  Users who know what they are doing can choose different ECDSA curves or validity periods; use the `-help` command-line flag to see the list of available options.
+
+The JSON object displayed should be enclosed in an array, and placed in the `tls` field for the domain where you want the TLSA record to appear.  Usually, this will be the `_443._tcp` subdomain of the domain name that points to the website.  An example of a typical configuration (using the Dehydrated form) is:
 
 ~~~
 {
@@ -79,4 +103,4 @@ The `cert.pem` and `key.pem` files can be used with HTTPS servers like Caddy, Ng
 
 Note that wildcard certificates are not currently supported; each domain name needs its own certificate.
 
-You can test your setup by visiting your `.bit` domain in Chromium on Windows when ncdns is installed.
+You can test your setup by visiting your `.bit` domain in a [Namecoin-supported TLS client]({{site.baseurl}}docs/tls-client/).

--- a/docs/name-owners/tls/index.md
+++ b/docs/name-owners/tls/index.md
@@ -51,7 +51,7 @@ Remember that if you have an `ns` record above the `tls` record, the `ns` record
 
 ~~~
 {
-    "ns": "ns21.cloudns.net",
+    "ns": "ns21.cloudns.net.",
     "map": {
         "_tcp": {
             "map": {

--- a/docs/name-owners/tls/index.md
+++ b/docs/name-owners/tls/index.md
@@ -10,14 +10,14 @@ ncdns includes the tool `generate_nmc_cert`.  This tool can be used to create a 
 Example usage:
 
 ~~~
-$ ./generate_nmc_cert -ecdsa-curve P256 -host www.example.bit -start-date "Jan 1 00:00:00 2017" -end-date "Jan 1 00:00:00 2020"
-2017/08/10 20:03:59 written cert.pem
-2017/08/10 20:03:59 written key.pem
-2017/08/10 20:03:59 Your Namecoin cert is: {"d8":[1, "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0bhYUDX2X+wpDs+Kdxfyz2goO7OygMZNZJStfBCOeJCA/LZnOvK2tkjIyMR+6cpG0o+GM74ALtwOdzdCBjL61w==",4944096,5259456,10,"MEUCIEdBFF9QqgIi64BM4XY1G3Fd9M2MgGdcYHsJzANhcxwwAiEAx/IqQR10fPia/d13z9EwHAgbilBM3kZCsW3LxnC3qqc="]}
-2017/08/10 20:03:59 SUCCESS: The cert rehydrated to an identical form.  Place the generated files in your HTTPS server, and place the above JSON in the "tls" field for your Namecoin name.
+$ ./generate_nmc_cert -host www.example.bit
+2019/12/11 06:47:41 written cert.pem
+2019/12/11 06:47:41 written key.pem
+2019/12/11 06:47:41 Your Namecoin cert is: {"d8":[1,"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOcD7/hnngrlW3XrTviUjXHgbvraj3mw7Wa872Iti6Dp0Jrb9P6ZsINAZSU4mucH37zX7/pscyb6UBO08SqDP+w==",5253561,5358681,10,"MEUCIQDQF/IAHUv1UqGTGrWMvu/Tfj6PiNRBb3eTerpyZmTJjAIgeEc3a8yyNY09PrDSGkEOh0T6ZmVqbesqnZVLYszEnWI="]}
+2019/12/11 06:47:41 SUCCESS: The cert rehydrated to an identical form.  Place the generated files in your HTTPS server, and place the above JSON in the "tls" field for your Namecoin name.
 ~~~
 
-(Users who know what they are doing can choose other ECDSA curves; use the `--help` option to see the list of available curves.)
+By default, certificates use the P256 curve and are valid from generation time for approximately 1 year.  Users who know what they are doing can choose different ECDSA curves or validity periods; use the `-help` option to see the list of available options.
 
 The JSON object displayed should be enclosed in an array, and placed in the `tls` field for the domain where you want the TLSA record to appear.  Usually, this will be the `_443._tcp` subdomain of the domain name that points to the website.  An example of a typical configuration is:
 


### PR DESCRIPTION
The TLS docs for name owners were outdated/erroneous in several ways:

* `NS` record in the example was missing the trailing period.
* `generate_nmc_cert`'s command-line args are now mostly optional.
* `generate_nmc_cert` now supports the `-use-ca` command-line flag.

This PR updates the docs accordingly.