### PR TITLE
Update index.md: retire Phelix

### DIFF
--- a/team/index.md
+++ b/team/index.md
@@ -14,11 +14,6 @@ Note that you should not blindly trust OpenPGP fingerprints listed on this page.
 **Chief Namecoin Scientist** <br>
 Daniel is our lead C++ developer, currently working on Namecoin Core. Daniel is also our specialist for identity applications, being the author of NameID, the Bitmessage Namecoin integration, and the OTR Namecoin integration. Daniel has a PhD in Mathematics from the University of Graz in Austria.
 
-## Phelix
-
-**Lead Windows Developer & Community Organizer** <br>
-Phelix (who goes by a pseudonym) is our lead Windows developer, and works on namecoind, Namecoin-Qt, NMControl, and other projects such as ANTPY. Phelix also handles financial matters and (along with Jeremy) fundraising, and is our longest-serving team member.
-
 ## Ryan Castellucci
 
 **Lead Security Engineer** <br>
@@ -83,6 +78,10 @@ We have several developers who are no longer active in the community, listed bel
 ## Mikhail Sindeyev (thecoder)
 
 Mikhail (then acting under a pseudonym) was our lead C++ developer for roughly a year (prior to Daniel), working on namecoind and creating Namecoin-Qt. Mikhail was a PhD student at Moscow State University. In 2014 Mikhail tragically died of a stroke at the age of 29. His identity was made public shortly after his death so that his great contribution to free speech technology would be recognized.
+
+## Phelix
+
+Phelix (a pseudonym) was community organizer and lead Windows developer. He worked on namecoind, Namecoin-Qt, NMControl, and other projects such as ANTPY. He is mostly retired but occasionally comments from the sidelines.
 
 ## Khalahan Henkh (khal)
 


### PR DESCRIPTION
Recreation of https://github.com/namecoin/namecoin.org/pull/490 which had to be nuked from orbit because of a broken merge signature.