### PR TITLE
Add textual <a> links to RSS feed

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ What does Namecoin do under the hood?
 * [Namecoin Identities](https://nameid.org)
 * [.bit DNS]({{site.baseurl}}dot-bit/)
 
-## News
+## News ([RSS Feed]({{site.baseurl}}feed.rss))
 
 {% for post in site.posts limit:10 %}
 {% assign content_words = post.content | number_of_words %}

--- a/news/index.md
+++ b/news/index.md
@@ -9,6 +9,8 @@ title: News
 
 {% assign permalinks = "1" %}
 
+([RSS Feed]({{site.baseurl}}feed.rss))
+
 {% for post in site.posts %}
 
 {% include single_post.md %}


### PR DESCRIPTION
Firefox removed the dedicated UI for RSS feeds in Firefox 64.  Adding textual `<a>` links to our RSS feed will ensure that Firefox users can easily discover the feed.