### PR TITLE
Update index.md (Removes several exchanges)

### DIFF
--- a/exchanges/index.md
+++ b/exchanges/index.md
@@ -31,15 +31,11 @@ title: Exchanges
 **Basic level exchanges**<br>
 [AltCoinTrader](https://www.altcointrader.co.za/nmc)<br>
 [Altilly](https://www.altilly.com/market/)<br>
-[Bleutrade](https://bleutrade.com/exchange/NMC/BTC)<br>
-[bx.in.th](https://bx.in.th)<br>
 [Coingi](https://coingi.com/trade/nmc-btc)<br>
 [Hodl Hodl](https://www.hodlhodl.com/)<br>
 [Livecoin](https://www.livecoin.net/)<br>
-[Nova Exchange](https://novaexchange.com/)<br>
 [QBTC](https://www.qbtc.ink/)<br>
 [SouthXchange](https://www.southxchange.com/)<br>
-[Tux Exchange](https://www.tuxexchange.com/trade?coin=NMC&market=BTC)<br>
 </span>
 
 Gold, silver and bronze level exchanges donate to the Namecoin project. The higher the donation the higher the level. Note that the exchanges are not verified in any way.


### PR DESCRIPTION
Remove bleutrade: delisted on 2019-July-15 https://bleutrade.com/announcements/
Remove bx.in.th: no longer offering crypto-currency trading services. Closed
Remove NovaExchange: Closed on Monday, October 7, 2019 trading on Nova Exchange will cease and close. 
Remove TuxExchange: http://tuxexchange.com/closing

Closes several PR/Isuess