### PR TITLE
Fix size of embedded images/videos on small screens

### DIFF
--- a/_includes/style.css
+++ b/_includes/style.css
@@ -91,6 +91,10 @@ nav ul li {
     padding: 40px;
 }
 
+#content video, #content img {
+    max-width: 100%;
+}
+
 table {
     border-collapse: collapse;
 }


### PR DESCRIPTION
The news posts from 2020-04-09 and 2020-04-30 are good test cases.