### PR TITLE
Bchain.info is dead, remove it

### DIFF
--- a/_data/explorers_currency.yml
+++ b/_data/explorers_currency.yml
@@ -1,3 +1,2 @@
-- "<a href='https://bchain.info/NMC/'>Bchain.info</a>"
 - "<a href='https://bitinfocharts.com/namecoin/explorer/'>BitInfoCharts</a>"
 - "<a href='https://nmc.tokenview.com/'>Tokenview</a>"

--- a/explorers/index.md
+++ b/explorers/index.md
@@ -12,6 +12,6 @@ title: Blockchain Explorers
 
 ### Currency operations only
 
-{% assign shuffled_explorers_currency = site.data.explorers_currency | sample: 3 %}{% for i in shuffled_explorers_currency %}{{ i }}<br>{% endfor %}
+{% assign shuffled_explorers_currency = site.data.explorers_currency | sample: 2 %}{% for i in shuffled_explorers_currency %}{{ i }}<br>{% endfor %}
 
 To get on the list please post on the [forum](https://forum.namecoin.org).


### PR DESCRIPTION
Resubmission of https://github.com/namecoin/namecoin.org/pull/562 to `beta` branch.