### PR TITLE
Add alternate Matrix webchat

### DIFF
--- a/resources/chat/index.md
+++ b/resources/chat/index.md
@@ -20,6 +20,7 @@ Two chat channels exist for Namecoin.
 * [OFTC IRC](ircs://irc.oftc.net:6697/#namecoin) (Tor-friendly)
 * Matrix (Tor-friendly): #namecoin:matrix.org
 * [Element web chat](https://app.element.io/#/room/#namecoin:matrix.org) (Tor-friendly)
+* [Alternate Element web chat](https://riot.kiwifarms.net/#/room/#namecoin:matrix.org) (Tor-friendly)
 * [OFTC web chat](https://webchat.oftc.net/?channels=%23namecoin)
 * [Freenode IRC](ircs://ajnvpgl6prmkb7yktvue6im5wiedlz2w32uhcwaamdiecdrfpwwgnlqd.onion:6697/#namecoin)
 * [Freenode IRC (clearnet)](ircs://chat.freenode.net:6697/#namecoin)

--- a/resources/chat/index.md
+++ b/resources/chat/index.md
@@ -19,8 +19,8 @@ Two chat channels exist for Namecoin.
 
 * [OFTC IRC](ircs://irc.oftc.net:6697/#namecoin) (Tor-friendly)
 * Matrix (Tor-friendly): #namecoin:matrix.org
-* [Element web chat](https://app.element.io/#/room/#namecoin:matrix.org) (Tor-friendly)
-* [Alternate Element web chat](https://riot.kiwifarms.net/#/room/#namecoin:matrix.org) (Tor-friendly)
+* [Element web chat](https://riot.kiwifarms.net/#/room/#namecoin:matrix.org) (Tor-friendly)
+* [Alternate Element web chat](https://app.element.io/#/room/#namecoin:matrix.org) (Tor-friendly, might need additional verification)
 * [OFTC web chat](https://webchat.oftc.net/?channels=%23namecoin)
 * [Freenode IRC](ircs://ajnvpgl6prmkb7yktvue6im5wiedlz2w32uhcwaamdiecdrfpwwgnlqd.onion:6697/#namecoin)
 * [Freenode IRC (clearnet)](ircs://chat.freenode.net:6697/#namecoin)
@@ -34,7 +34,8 @@ Two chat channels exist for Namecoin.
 
 * [OFTC IRC](ircs://irc.oftc.net:6697/#namecoin-dev) (Tor-friendly)
 * Matrix (Tor-friendly): #namecoin-dev:matrix.org
-* [Element web chat](https://app.element.io/#/room/#namecoin-dev:matrix.org) (Tor-friendly)
+* [Element web chat](https://riot.kiwifarms.net/#/room/#namecoin-dev:matrix.org) (Tor-friendly)
+* [Alternate Element web chat](https://app.element.io/#/room/#namecoin-dev:matrix.org) (Tor-friendly, might need additional verification)
 * [OFTC web chat](https://webchat.oftc.net/?channels=%23namecoin-dev)
 * [Freenode IRC](ircs://ajnvpgl6prmkb7yktvue6im5wiedlz2w32uhcwaamdiecdrfpwwgnlqd.onion:6697/#namecoin-dev)
 * [Freenode IRC (clearnet)](ircs://chat.freenode.net:6697/#namecoin-dev)


### PR DESCRIPTION
The proprietor stated:

* we don't require email verification, it could possibly change, but only in reaction to a specific ongoing attack
* also I run our pleroma/fediverse instance at kiwifarms.cc, which also does not require an email verification. We use a self-hosted/non-google/non-invasive CAPTCHA on that service

It benefits decentralization if not everyone uses the same homeserver. Maybe you should use the shuffle script for the ranking too, or even put this one first.