### PR TITLE
Replace infinitive ("access") with gerund ("accessing") in "What can Namecoin be used for?" list

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,11 +17,11 @@ title: Namecoin
 
 ## What can Namecoin be used for?
 
-* Protect free-speech rights online by making the web more resistant to censorship.
-* Attach identity information such as GPG and OTR keys and email, Bitcoin, and Bitmessage addresses to an identity of your choice.
+* Protecting free-speech rights online by making the web more resistant to censorship.
+* Attaching identity information such as GPG and OTR keys and email, Bitcoin, and Bitmessage addresses to an identity of your choice.
 * Human-meaningful Tor .onion domains.
 * Decentralized TLS (HTTPS) certificate validation, backed by blockchain consensus.
-* Access websites using the .bit top-level domain.
+* Accessing websites using the .bit top-level domain.
 
 </div>
 


### PR DESCRIPTION
Before: "Namecoin can be used for protect [sic] free-speech rights online by making the web more resistant to censorship."

After: "Namecoin can be used for protecting free-speech rights online by making the web more resistant to censorship."

Fixes #592.