### PR TITLE
Add titles to posts on front page

### DIFF
--- a/index.md
+++ b/index.md
@@ -53,6 +53,7 @@ What does Namecoin do under the hood?
 {% for post in site.posts limit:10 %}
 {% assign content_words = post.content | number_of_words %}
 {% assign excerpt_words = post.excerpt | number_of_words %}
+###[{{ post.title }}]({{ post.url | relative_url }})
 **[{{ post.date | date: "%Y-%m-%d" }}]({{ post.url | relative_url }})** {{ post.excerpt | remove: '<p>' | remove: '</p>' }}  {% if content_words != excerpt_words %} [Read more...]({{ post.url | relative_url }}) {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
This PR makes the site show the titles of the articles on the front page; should look similar to https://www.namecoin.org/news/, but with smaller headlines and no author.