### PR TITLE
Public Domain

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: Website License
+title: Public Domain
 ---
 
 {::options parse_block_html="true" /}
 
-Unless otherwise noted, the following Git commits to this website are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/):
+**All content on this website is in the public domain.**
 
-* All Git commits that were merged on or after November 13, 2021.
-* All Git commits copyrighted by Jeremy Rand or Brandon Roberts.
+## Exception:
+Git commits merged on or after November 13, 2021 by [Jeremy Rand](https://github.com/JeremyRand) and [Brandon Roberts](https://github.com/brandonrobertz) are licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
Make it clear that all content on Namecoin.org is in the **public domain**, except for those git commits that are submitted and merged by Jeremy Rand (@JeremyRand) and Brandon Roberts @brandonrobertz).