### PR TITLE
Removing imaginary positions, unncessarry publicity, a bunch of PGP keys...

### DIFF
--- a/team/index.md
+++ b/team/index.md
@@ -11,72 +11,20 @@ Note that you should not blindly trust crypto fingerprints listed on this page. 
 
 ## Daniel Kraft (domob)
 
-**Chief Namecoin Scientist** <br>
-Daniel is our lead C++ developer, currently working on Namecoin Core. Daniel is also our specialist for identity applications, being the author of NameID, the Bitmessage Namecoin integration, and the OTR Namecoin integration. Daniel has a PhD in Mathematics from the University of Graz in Austria.
+Daniel is our lead C++ developer, currently working on Namecoin Core. Daniel is also our specialist for identity applications, being the author of NameID, the Bitmessage Namecoin integration, and the OTR Namecoin integration.
 
 OpenPGP: `1142 850E 6DFF 65BA 63D6  88A8 B249 2AC4 A733 0737` [(download public key)]({{ "/DanielKraft.asc" | relative_url }})
 
-## Ryan Castellucci
-
-**Lead Security Engineer** <br>
-Ryan is our security specialist and all-around-badass, handling everything from web infrastructure to C++ development to crisis management.
-
 ## Jeremy Rand (biolizard89)
 
-**Lead Application Engineer & Community Organizer** <br>
-Jeremy is our .bit application specialist, and works on our codebases relating to TLS, Tor, and SPV, among other projects. Jeremy also handles fundraising (along with Phelix), represents Namecoin at conferences, and acts as our build engineer. Outside of Namecoin, he has a background in console game hacking (in particular, synchronizing multiple game consoles with each other and with virtual reality hardware) and educational robotics. Jeremy has a Master's degree in Computer Science and is a member of the [State Sponsored Actors Club](https://www.state-sponsored-actors.org/).
+Jeremy is our .bit application specialist, and works on our codebases relating to TLS, Tor, and SPV, among other projects.
 
-OpenPGP (Electrum-NMC signer): `A0BE 08C8 6566 1A93 16E0  A7FF 762E D28D A5C0 07DA` [(download public key)]({{ "/JeremyRand-Electrum.asc" | relative_url }})<br>
 OpenPGP (Email): `1D04 FB9D 50BF 2A8E 9F3E  58AD DC7E 7F8A E30E 73E6` [(download public key)]({{ "/JeremyRand-Email.asc" | relative_url }})<br>
-OpenPGP (Gitian signer): `9CDA F04A 7290 3BFE C095 9DBE 2DBE 339E 29F6 294C` [(download public key)]({{ "/JeremyRand-Gitian.asc" | relative_url }})<br>
-OpenPGP (Git signer): `A9F5 A19D 56DB 3217 70B6  7238 EB03 139A 459D D06E` [(download public key)]({{ "/JeremyRand-Git-2021.asc" | relative_url }})<br>
-OpenPGP (Jekyll signer): `9405 8478 534E 143D 1E78  A6BB 5E23 7E1F 50A5 A878` [(download public key)]({{ "/JeremyRand-Jekyll.asc" | relative_url }})<br>
-OpenPGP (RBM signer): `B18A 917F B906 3B6B 0F13  2374 8298 5AFE 22E0 F366` [(download public key)]({{ "/JeremyRand-RBM.asc" | relative_url }})<br>
-OpenPGP (primary) (superseded 2021): `5174 0B7C 732D 572A 3140 4010 6605 55E1 F8F7 BF85` [(download public key)]({{ "/JeremyRand.asc" | relative_url }})<br>
-OpenPGP (Git signer) (superseded 2021): `0729 7809 7FC1 25E6 685B CE40 FD75 50C2 EB80 0711` [(download public key)]({{ "/JeremyRand-Git.asc" | relative_url }})<br>
-Ricochet: `ricochet:ujb6mp55tlzfpfdi`<br>
-Ricochet-Refresh: `ricochet:mjacuh3sbb4sg352yxwmtjwxvnbkdao6eooedlxhywbqon5ipscxasad`<br>
-Cwtch: `degdcodd2fhlpv6so3ewyh2dcsyg4732ujauuzx63t7qlavumnyt4uyd`
-
-## Brandon "Brando" Roberts
-
-**Lead C++ GUI Engineer** <br>
-Brandon is a hacker with a background in independent journalism and machine learning who works on Namecoin-Qt. In addition to his work on Namecoin Core, he maintains a Namecoin port of Bitcore, Bitcore-Namecoin. When he's not on his computer he's probably skateboarding.
-
-## Joseph Bisch
-
-**Lead Porting & Reproducible Build Engineer** <br>
-Joseph works on porting Bitcoin software to Namecoin, and also specializes in reproducible builds.  Outside of Namecoin, he has done development work relating to Bitcoin wallet software, the Gitian reproducible build tool (his contributions are primarily used by The Tor Project), and the Debian GNU/Linux distribution.
-
-## Andrew Colosimo (Snailbrain)
-
-**Developer & Community Organizer** <br>
-Snailbrain (who prefers his pseudonym) is an IT specialist who initiated the creation of Namecoin-Qt alongside Mikhail, and was the main funder of Namecoin development during most of 2013; he also contributes to testing and development. Snailbrain is also the creator of the Huntercoin concept, which is currently Namecoin’s only fork. Huntercoin’s current development has improved Namecoin on many levels with the help of the coding expertise of Daniel.
-
-## Cassini
-
-**OS X Maintainer** <br>
-Cassini (working under a pseudonym) holds the reins in the Mac OS X world. He is another dauntless tester and one of our blockchain watchdogs.
-
-## Peter Conrad (pmc)
-
-**Linux Build Maintainer** <br>
-Peter uses his 20 years of Unix/Linux experience to manage Namecoin packages for the major Linux distributions. Outside the Namecoin community he is working as a freelance software developer.
 
 ## Ahmed Bodiwala
 
 **Electrum Specialist** <br>
 Ahmed did the initial work in porting Electrum to Namecoin.  The result of Ahmed's work (Electrum-NMC) is currently Namecoin's flagship lightweight SPV wallet.
-
-## Aerth
-
-**cgo Specialist** <br>
-Aerth did the initial work in creating pkcs11mod (a Go library for creating PKCS#11 modules) and ncp11 (a PKCS#11 module for Namecoin TLS certificates).  The result of Aerth's work was presented at the 35C3 Critical Decentralization Cluster, and is expected to become Namecoin's flagship method of accessing HTTPS websites in Firefox, Tor Browser, and Chromium.
-
-## Lola Dam
-
-**ZeroNet Specialist** <br>
-Lola works on enhancing Namecoin integration in ZeroNet, a decentralized website hosting system loosely based on BitTorrent.
 
 ## Anonymous Developers
 
@@ -114,18 +62,6 @@ Appamatto is the author of the BitDNS and BitX proposals in 2010, which proposed
 
 Aaron was the author of the Nakanames proposal in 2011, which was later implemented as Namecoin.  Aaron is well-known for co-creating RSS, Creative Commons, Demand Progress, and Reddit.  Aaron was murdered by the U.S. government in 2013.  The atomic unit of NMC, the *swartz*, is named in Aaron's honor.
 
-## Theymos
-
-Theymos proposed that Appamatto's BitDNS design utilize a native token-like currency instead of only names.  Theymos's proposal is responsible for non-miners being able to trustlessly register Namecoin names.
-
-## Dan Kaminsky
-
-Dan suggested to Aaron that Zooko's Triangle, if accurate, constituted an impossibility proof of Bitcoin, because a currency and a naming system reduce to the same problem.  Dan's insight directly led to Aaron proposing Nakanames, which used a Bitcoin-like system to solve Zooko's Triangle.  Dan is well-known for discovering and coordinating a fix for a large-scale DNS cache poisoning vulnerability, and for being one of the Recovery Key Share Holders for the ICANN root zone.
-
 ## Satoshi Nakamoto
 
 Satoshi invented AuxPoW mining, which he proposed in order to allow BitDNS and Bitcoin to share miners while using separate blockchains.  Satoshi is well-known as the inventor of Bitcoin.
-
-## Zooko Wilcox
-
-Zooko formalized the problem of Zooko's Triangle, which specified three properties of a naming system that were considered desirable, while conjecturing that only two could be achieved by any given naming system.  Namecoin was the first naming system to achieve all three.  Zooko is well-known for his work on the Tahoe Least-Authority File Store and for being a co-founder of the Zcash anonymity-focused cryptocurrency.


### PR DESCRIPTION
.. and people who has no connection to Namecoin.


**Removing imaginary positions, in reality barely 4 people working on Namecoin.** 

Namecoin.org is a not a blog or personal profile where you have to stuff things like education or what club you member of.

@domob1812 and @JeremyRand's profile cleaned up. 
@rllola is removed as she is working on filecoin (@ipfs) which is the competitor of ZeroNet, additionally she had never contributed to Namecoin.

Removing a bunch of people who similarly to rllola never contributed anything to Namecoin. 

**Suggesting this and that to someone is not a contribution but a mere opinion.** 

The team page written like an advertise for fundraising purposes, giving credits to everyone who doesn't deserve it, meanwhile those who contribute to Namecoin are not credited at all. 