### PR TITLE
Reorganize the downloads page.

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -5,68 +5,6 @@ title: Download
 
 {::options parse_block_html="true" /}
 
-## ncdns
-
-ncdns is software for accessing `.bit` domain names.  If you want to access `.bit` domain names, ncdns is most likely what you want to install.
-
-See the [ncdns documentation]({{ "/docs/ncdns" | relative_url }}).
-
-Current release: v0.3.1 (Windows 64-bit x86), v0.3 (other platforms).
-
-<div class="row">
-
-<div class="col-sm-4">
-
-### Windows
-
-The installer also automatically installs and configures a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and Dnssec-Trigger/Unbound, and sets up TLS certificate validation in any supported web browsers that are installed (see documentation for a list of supported browsers).  It's basically all you need for browsing `.bit` domain names.
-
-* [64-bit x86 installer]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/ncdns-0.3.1-x86_64-install-fb9d49.exe)
-
-Plain binaries are useful for advanced users only.  They require setting up a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and a recursive DNS resolver (e.g. Unbound) separately; additional setup is required for TLS certificate validation.
-
-* [64-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/ncdns-0.3.1-windows-x86_64-af37f1.tar.xz)
-* [32-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-windows-i686-e076b4.tar.xz)
-
-* [Installer Source Code](https://github.com/namecoin/ncdns-nsis)
-
-</div>
-
-<div class="col-sm-4">
-
-### GNU/Linux
-
-Requires setting up a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and a recursive DNS resolver (e.g. Unbound) separately; additional setup is required for TLS certificate validation.
-
-* [64-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-linux-x86_64-e41ca2.tar.xz)
-* [32-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-linux-i686-990513.tar.xz)
-
-* [Distro packages](https://repology.org/project/ncdns/versions)
-
-</div>
-
-<div class="col-sm-4">
-
-### macOS
-
-Requires setting up a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and a recursive DNS resolver (e.g. Unbound) separately; additional setup is required for TLS certificate validation.
-
-* [64-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-osx-x86_64-b17766.tar.xz)
-
-</div>
-
-</div>
-
-* [v0.3.1 Hashes]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/sha256sums-unsigned-build.txt)
-* [v0.3.1 Signature (Release signed by Jeremy Rand)]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/sha256sums-unsigned-build.txt.asc)
-* [v0.3 Hashes]({{ site.files_url }}/files/ncdns/ncdns-0.3/sha256sums-unsigned-build.txt)
-* [v0.3 Signature (Release signed by Jeremy Rand)]({{ site.files_url }}/files/ncdns/ncdns-0.3/sha256sums-unsigned-build.txt.asc)
-* [Source Code](https://github.com/namecoin/ncdns)
-* [rbm Build Harness Source Code](https://github.com/namecoin/ncdns-repro)
-
-## Tor Browser
-
-[Tor Browser Nightly](https://nightlies.tbb.torproject.org/nightly-builds/tor-browser-builds/) for GNU/Linux has experimental Namecoin resolution built-in.  Set the environment variable `TOR_ENABLE_NAMECOIN=1` to use it.
 
 ## Namecoin Core Client (Stable Release)
 
@@ -211,6 +149,70 @@ Download [v0.3.80 Namecoin-Qt]({{ site.files_url }}/files/namecoin-core/namecoin
 </div>
 
 </div>
+
+## ncdns
+
+ncdns is software for accessing `.bit` domain names.  If you want to access `.bit` domain names, ncdns is most likely what you want to install.
+
+See the [ncdns documentation]({{ "/docs/ncdns" | relative_url }}).
+
+Current release: v0.3.1 (Windows 64-bit x86), v0.3 (other platforms).
+
+<div class="row">
+
+<div class="col-sm-4">
+
+### Windows
+
+The installer also automatically installs and configures a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and Dnssec-Trigger/Unbound, and sets up TLS certificate validation in any supported web browsers that are installed (see documentation for a list of supported browsers).  It's basically all you need for browsing `.bit` domain names.
+
+* [64-bit x86 installer]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/ncdns-0.3.1-x86_64-install-fb9d49.exe)
+
+Plain binaries are useful for advanced users only.  They require setting up a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and a recursive DNS resolver (e.g. Unbound) separately; additional setup is required for TLS certificate validation.
+
+* [64-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/ncdns-0.3.1-windows-x86_64-af37f1.tar.xz)
+* [32-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-windows-i686-e076b4.tar.xz)
+
+* [Installer Source Code](https://github.com/namecoin/ncdns-nsis)
+
+</div>
+
+<div class="col-sm-4">
+
+### GNU/Linux
+
+Requires setting up a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and a recursive DNS resolver (e.g. Unbound) separately; additional setup is required for TLS certificate validation.
+
+* [64-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-linux-x86_64-e41ca2.tar.xz)
+* [32-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-linux-i686-990513.tar.xz)
+
+* [Distro packages](https://repology.org/project/ncdns/versions)
+
+</div>
+
+<div class="col-sm-4">
+
+### macOS
+
+Requires setting up a Namecoin client (Namecoin Core, ConsensusJ-Namecoin, or Electrum-NMC) and a recursive DNS resolver (e.g. Unbound) separately; additional setup is required for TLS certificate validation.
+
+* [64-bit x86 plain binaries]({{ site.files_url }}/files/ncdns/ncdns-0.3/ncdns-0.3-osx-x86_64-b17766.tar.xz)
+
+</div>
+
+</div>
+
+* [v0.3.1 Hashes]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/sha256sums-unsigned-build.txt)
+* [v0.3.1 Signature (Release signed by Jeremy Rand)]({{ site.files_url }}/files/ncdns/ncdns-0.3.1/sha256sums-unsigned-build.txt.asc)
+* [v0.3 Hashes]({{ site.files_url }}/files/ncdns/ncdns-0.3/sha256sums-unsigned-build.txt)
+* [v0.3 Signature (Release signed by Jeremy Rand)]({{ site.files_url }}/files/ncdns/ncdns-0.3/sha256sums-unsigned-build.txt.asc)
+* [Source Code](https://github.com/namecoin/ncdns)
+* [rbm Build Harness Source Code](https://github.com/namecoin/ncdns-repro)
+
+## Tor Browser
+
+[Tor Browser Nightly](https://nightlies.tbb.torproject.org/nightly-builds/tor-browser-builds/) for GNU/Linux has experimental Namecoin resolution built-in.  Set the environment variable `TOR_ENABLE_NAMECOIN=1` to use it.
+
 
 ## NMControl Middleware
 


### PR DESCRIPTION
The Namecoin Core clients have been moved to the top of the page. Those are the most important.