### PR TITLE
Front page: Deprioritize identity use cases

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,10 +18,10 @@ title: Namecoin
 ## What can Namecoin be used for?
 
 * Protect free-speech rights online by making the web more resistant to censorship.
-* Attach identity information such as GPG and OTR keys and email, Bitcoin, and Bitmessage addresses to an identity of your choice.
 * Human-meaningful Tor .onion domains.
 * Decentralized TLS (HTTPS) certificate validation, backed by blockchain consensus.
 * Access websites using the .bit top-level domain.
+* Attach identity information such as GPG and OTR keys and email, Bitcoin, and Bitmessage addresses to an identity of your choice.
 
 </div>
 


### PR DESCRIPTION
Identity use cases were bumped to the top of the list in https://github.com/namecoin/namecoin.org/pull/36 (2015). The intent was that this would be a temporary change, until DNS use cases had an automated installer.

ncdns-nsis has existed since 2017, but somehow we never got around to reverting this change until now. v0v