### PR TITLE
explorers: add mstrofnone nmc-rpc-explorer (clearnet + Tor)

### DIFF
--- a/explorers/index.md
+++ b/explorers/index.md
@@ -8,6 +8,7 @@ title: Blockchain Explorers
 ### With support for name and currency operations
 
 [Cyphrs Namecoin Explorer](https://namecoin.cyphrs.com/) (free software; consensus-safe)<br>
+[mstrofnone nmc-rpc-explorer](http://23.158.233.10:3002/) ([Tor](http://6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion:8080/)) (free software; consensus-safe; merge-mining-aware mining summary; full name-op aware mempool view)<br>
 {% assign shuffled_explorers_name_nonfree = site.data.explorers_name_nonfree | sample: 1 %}{% for i in shuffled_explorers_name_nonfree %}{{ i }}<br>{% endfor %}
 [Tokenview](https://nmc.tokenview.com/) (non-free software; requires JavaScript)<br>
 


### PR DESCRIPTION
Adds an entry to /explorers for a free-software, consensus-safe Namecoin explorer derived from janoside/btc-rpc-explorer with Namecoin-specific support layered on top.

## Why list it

Namecoin currently has only one free-software, consensus-safe explorer in the top section ([Cyphrs](https://namecoin.cyphrs.com/)). This adds a second, with a complementary feature set:

- **Full name-op aware mempool view** ([`/mempool-name-ops`](http://6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion:8080/mempool-name-ops)) — every name_new, name_firstupdate, and name_update queued for the next block, bucketed by op kind, backed by Namecoin Core's `name_pending` RPC.
- **`import` reference detection** per [ifa-0001 §"import"](https://github.com/namecoin/proposals/blob/master/ifa-0001.md#import) — references rendered as clickable links to import targets (no recursive resolution; just discovery).
- **NameID / Nostr identity linking** — NameID fields (name, email, www, bitcoin, namecoin, tor, pgp, gpg) extracted from `id/<name>` records into a typed key/value table; Nostr pubkeys (single-identity `nostr.pubkey` and multi-identity `nostr.names`/`nostr.relays`) encoded to NIP-19 npub and linked to njump.me; implied `<localPart>@<label>.bit` NIP-05 identifiers rendered alongside.
- **Merge-mining-aware [mining-summary](http://6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion:8080/mining-summary)** — scans the parent Bitcoin coinbase tag carried inside the auxpow blob (`auxpow.tx.vin[0].coinbase`), surfacing the actual NMC mining pool ("AntPool", "F2Pool", "ViaBTC", etc.) instead of "Unknown" the way most upstream-only explorers do.

## Endpoints

- Clearnet: http://23.158.233.10:3002/
- Tor: http://6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion:8080/

The Tor endpoint shares the same hidden-service identity as the [`relay.testls.bit`](https://github.com/vitorpamplona/amethyst/pull/2612) Nostr relay (port 8080 multiplexed under one HiddenServiceDir), so an Amethyst client that already has the relay configured can reach the explorer through the same circuit.

## Source

- Fork (master): https://github.com/mstrofnone/nmc-rpc-explorer
- Upstream PR queue: [namecoin/nmc-rpc-explorer #13–#19](https://github.com/namecoin/nmc-rpc-explorer/pulls?q=author%3Amstrofnone)

## Verifier

Anyone can verify the explorer is consensus-safe by inspecting the source: it queries `getblock`, `getrawtransaction`, `name_show`, `name_history`, `name_scan`, and `name_pending` directly against a local Namecoin Core node \u2014 no third-party indexers in the trust path.